### PR TITLE
Fix: Correct class binding for reCAPTCHA directive

### DIFF
--- a/libs/re-captcha/src/lib/re-captcha/re-captcha-base.ts
+++ b/libs/re-captcha/src/lib/re-captcha/re-captcha-base.ts
@@ -22,7 +22,7 @@ type ErrorCallbackFn = () => void;
 @Directive({
   host: {
     '[id]': 'id',
-    'class.g-recaptcha': 'true',
+    '[class.g-recaptcha]': 'true',
   },
 })
 export class ScReCaptchaBase implements OnInit, ControlValueAccessor {


### PR DESCRIPTION
This PR updates the ScReCaptchaBase directive to correctly bind the g-recaptcha class using Angular's property binding syntax.