### PR TITLE
feat(query-param-state): make signal source of truth with debounced U…

### DIFF
--- a/apps/showcase/src/app/pages/docs/query-param-state/demos/demo-query-param-state-demo-container.ts
+++ b/apps/showcase/src/app/pages/docs/query-param-state/demos/demo-query-param-state-demo-container.ts
@@ -92,7 +92,10 @@ import {
   encapsulation: ViewEncapsulation.None,
 })
 export class DemoQueryParamStateDemo {
-  readonly search = injectQueryParam('q', parseAsString.withDefault(''));
+  readonly search = injectQueryParam(
+    'q',
+    parseAsString.withDefault('').withOptions({ debounceMs: 300 }),
+  );
 
   readonly page = injectQueryParam('page', parseAsInteger.withDefault(1));
 

--- a/apps/showcase/src/app/pages/docs/query-param-state/demos/demo-query-param-state-demo.ts
+++ b/apps/showcase/src/app/pages/docs/query-param-state/demos/demo-query-param-state-demo.ts
@@ -71,7 +71,10 @@ import {
   encapsulation: ViewEncapsulation.None,
 })
 export class DemoQueryParamStateDemo {
-  readonly search = injectQueryParam('q', parseAsString.withDefault(''));
+  readonly search = injectQueryParam(
+    'q',
+    parseAsString.withDefault('').withOptions({ debounceMs: 300 }),
+  );
 
   readonly page = injectQueryParam('page', parseAsInteger.withDefault(1));
 

--- a/apps/showcase/src/app/query-param-state.spec.ts
+++ b/apps/showcase/src/app/query-param-state.spec.ts
@@ -1,0 +1,74 @@
+import { Component, inject } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { Router, provideRouter } from '@angular/router';
+import {
+  injectQueryParam,
+  parseAsInteger,
+  parseAsString,
+} from '@semantic-components/ui-lab';
+
+@Component({ template: '' })
+class TwoCallSites {
+  readonly a = injectQueryParam('q', parseAsString.withDefault(''));
+  readonly b = injectQueryParam('q', parseAsString.withDefault(''));
+  readonly router = inject(Router);
+}
+
+@Component({ template: '' })
+class Truncating {
+  readonly page = injectQueryParam('page', parseAsInteger.withDefault(1));
+}
+
+async function mount<T>(type: new () => T, url = '/'): Promise<T> {
+  TestBed.configureTestingModule({
+    providers: [provideRouter([{ path: '**', children: [] }])],
+  });
+  await TestBed.inject(Router).navigateByUrl(url);
+  return TestBed.createComponent(type).componentInstance;
+}
+
+describe('injectQueryParam', () => {
+  it('seeds both call sites for a key from the URL', async () => {
+    const c = await mount(TwoCallSites, '/?q=hello');
+    expect(c.a.value()).toBe('hello');
+    expect(c.b.value()).toBe('hello');
+  });
+
+  it('propagates a write to a sibling call site in the same tick', async () => {
+    const c = await mount(TwoCallSites, '/?q=hello');
+
+    c.a.set('world');
+    TestBed.tick();
+
+    // Before the fix this stayed 'hello' until the router round-trip landed.
+    expect(c.b.value()).toBe('world');
+  });
+
+  it('propagates clear() to a sibling call site', async () => {
+    const c = await mount(TwoCallSites, '/?q=hello');
+
+    c.a.clear();
+    TestBed.tick();
+
+    expect(c.b.value()).toBe('');
+  });
+
+  it('reflects external navigation into every call site', async () => {
+    const c = await mount(TwoCallSites, '/?q=hello');
+
+    await c.router.navigateByUrl('/?q=external');
+    TestBed.tick();
+
+    expect(c.a.value()).toBe('external');
+    expect(c.b.value()).toBe('external');
+  });
+
+  it('corrects a value the parser cannot round-trip', async () => {
+    const c = await mount(Truncating, '/?page=2');
+
+    c.page.set(3.7);
+    TestBed.tick();
+
+    expect(c.page.value()).toBe(3);
+  });
+});

--- a/libs/ui-lab/src/lib/utilities/query-param-state/inject-query-param.ts
+++ b/libs/ui-lab/src/lib/utilities/query-param-state/inject-query-param.ts
@@ -88,11 +88,18 @@ export function injectQueryParam<T>(
       }
     });
 
-  // Signal is the source of truth; URL is a derived view of it.
   const debounceMs = parser._options?.debounceMs ?? 0;
   const debouncedView = debounceMs > 0 ? debounced(sig, debounceMs) : null;
   const read = debouncedView ? () => debouncedView.value() : () => sig();
 
+  // The signal is the write origin: `set`/`clear` only touch the signal, and
+  // this effect projects it onto the URL. The URL round-trips back in via the
+  // queryParamMap subscription above, so this is a cycle — it converges because
+  // a write is skipped when the serialised value already matches the live URL.
+  // That guard is required, not an optimisation: parsers returning reference
+  // types (parseAsJson, parseAsArrayOf, the Date parsers) hand back a fresh
+  // object on every navigation, which re-notifies the signal and re-runs this
+  // effect. Without the guard each write would trigger the next.
   let firstRun = true;
   effect(() => {
     const value = read();

--- a/libs/ui-lab/src/lib/utilities/query-param-state/inject-query-param.ts
+++ b/libs/ui-lab/src/lib/utilities/query-param-state/inject-query-param.ts
@@ -1,13 +1,11 @@
 import {
-  DestroyRef,
   WritableSignal,
   debounced,
   effect,
   inject,
-  signal,
+  linkedSignal,
+  untracked,
 } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { ActivatedRoute } from '@angular/router';
 import { QueryParamSyncService } from './query-param-sync';
 import type {
   ParserBuilder,
@@ -49,20 +47,15 @@ export function injectQueryParam<T>(
   parser: ParserBuilder<T> | ParserBuilderWithDefault<T>,
 ): QueryParamState<T | null> {
   const sync = inject(QueryParamSyncService);
-  const route = inject(ActivatedRoute);
-  const destroyRef = inject(DestroyRef);
 
   const hasDefault = '_default' in parser && parser._default !== undefined;
   const defaultValue: T | null = hasDefault
     ? (parser as ParserBuilderWithDefault<T>)._default
     : null;
 
-  // Read initial value from URL snapshot
-  const rawInit = sync.getRaw(key);
-  const initialParsed = rawInit !== null ? parser.parse(rawInit) : null;
-  const initialValue: T | null = initialParsed ?? defaultValue;
-
-  const sig = signal<T | null>(initialValue);
+  // Shared per-key raw value. Every call site for `key` observes this same
+  // signal, and the service keeps it current from a single route subscription.
+  const raw = sync.raw(key);
 
   const isDefault = (value: T | null): boolean => {
     if (!hasDefault || value === null || defaultValue === null) return false;
@@ -71,46 +64,45 @@ export function injectQueryParam<T>(
 
   // If the URL carries the default value explicitly, strip it so the canonical
   // URL only ever contains non-default state.
+  const rawInit = untracked(raw);
+  const initialParsed = rawInit !== null ? parser.parse(rawInit) : null;
   if (rawInit !== null && initialParsed !== null && isDefault(initialParsed)) {
     sync.write(key, null, parser._options);
   }
 
-  // External URL changes (back/forward, manual edits) flow into the signal.
-  route.queryParamMap
-    .pipe(takeUntilDestroyed(destroyRef))
-    .subscribe((params) => {
-      const raw = params.has(key) ? params.get(key) : null;
-      if (raw === null) {
-        sig.set(defaultValue);
-      } else {
-        const parsed = parser.parse(raw);
-        sig.set(parsed ?? defaultValue);
-      }
-    });
+  // Typed view of the shared raw value, locally writable so `set` can update
+  // optimistically before the URL catches up. External changes (back/forward,
+  // hand-edited links, a sibling call site) reset it through `source`.
+  const sig = linkedSignal<string | null, T | null>({
+    source: raw,
+    computation: (value) =>
+      value === null ? defaultValue : (parser.parse(value) ?? defaultValue),
+  });
 
-  const debounceMs = parser._options?.debounceMs ?? 0;
-  const debouncedView = debounceMs > 0 ? debounced(sig, debounceMs) : null;
-  const read = debouncedView ? () => debouncedView.value() : () => sig();
-
-  // The signal is the write origin: `set`/`clear` only touch the signal, and
-  // this effect projects it onto the URL. The URL round-trips back in via the
-  // queryParamMap subscription above, so this is a cycle — it converges because
-  // a write is skipped when the serialised value already matches the live URL.
-  // That guard is required, not an optimisation: parsers returning reference
-  // types (parseAsJson, parseAsArrayOf, the Date parsers) hand back a fresh
-  // object on every navigation, which re-notifies the signal and re-runs this
-  // effect. Without the guard each write would trigger the next.
-  let firstRun = true;
+  // Local writes publish to the shared raw value immediately, so sibling call
+  // sites for the same key converge in this tick rather than waiting on the URL
+  // round-trip — which `debounceMs` can defer for as long as the user keeps
+  // typing. No "skip the first run" guard here: `raw` is seeded from the URL,
+  // so the initial pass is already a no-op by equality, and skipping a run by
+  // counter would swallow a write made before the first change detection.
   effect(() => {
-    const value = read();
-    if (firstRun) {
-      firstRun = false;
-      return;
-    }
-    const raw =
+    const value = sig();
+    const next =
       value === null || isDefault(value) ? null : parser.serialize(value);
-    if (raw === sync.getRaw(key)) return;
-    sync.write(key, raw, parser._options);
+    if (next !== untracked(raw)) raw.set(next);
+  });
+
+  // The URL is a projection of the shared raw value, optionally debounced. The
+  // write is skipped when it already matches the live URL: that guard is what
+  // stops the URL → signal → URL cycle from sustaining itself.
+  const debounceMs = parser._options?.debounceMs ?? 0;
+  const debouncedRaw = debounceMs > 0 ? debounced(raw, debounceMs) : null;
+  const readRaw = debouncedRaw ? () => debouncedRaw.value() : () => raw();
+
+  effect(() => {
+    const next = readRaw();
+    if (next === sync.getRaw(key)) return;
+    sync.write(key, next, parser._options);
   });
 
   return {

--- a/libs/ui-lab/src/lib/utilities/query-param-state/inject-query-param.ts
+++ b/libs/ui-lab/src/lib/utilities/query-param-state/inject-query-param.ts
@@ -1,4 +1,11 @@
-import { DestroyRef, WritableSignal, inject, signal } from '@angular/core';
+import {
+  DestroyRef,
+  WritableSignal,
+  debounced,
+  effect,
+  inject,
+  signal,
+} from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute } from '@angular/router';
 import { QueryParamSyncService } from './query-param-sync';
@@ -68,7 +75,7 @@ export function injectQueryParam<T>(
     sync.write(key, null, parser._options);
   }
 
-  // Subscribe to route changes and keep signal in sync
+  // External URL changes (back/forward, manual edits) flow into the signal.
   route.queryParamMap
     .pipe(takeUntilDestroyed(destroyRef))
     .subscribe((params) => {
@@ -81,19 +88,32 @@ export function injectQueryParam<T>(
       }
     });
 
+  // Signal is the source of truth; URL is a derived view of it.
+  const debounceMs = parser._options?.debounceMs ?? 0;
+  const debouncedView = debounceMs > 0 ? debounced(sig, debounceMs) : null;
+  const read = debouncedView ? () => debouncedView.value() : () => sig();
+
+  let firstRun = true;
+  effect(() => {
+    const value = read();
+    if (firstRun) {
+      firstRun = false;
+      return;
+    }
+    const raw =
+      value === null || isDefault(value) ? null : parser.serialize(value);
+    if (raw === sync.getRaw(key)) return;
+    sync.write(key, raw, parser._options);
+  });
+
   return {
     value: sig as WritableSignal<T>,
 
     set(value: T | null): void {
-      const raw =
-        value === null || isDefault(value) ? null : parser.serialize(value);
-      sync.write(key, raw, parser._options);
-      // Optimistic local update for instant UI response
       sig.set(value ?? defaultValue);
     },
 
     clear(): void {
-      sync.write(key, null, parser._options);
       sig.set(defaultValue);
     },
   };

--- a/libs/ui-lab/src/lib/utilities/query-param-state/query-param-sync.ts
+++ b/libs/ui-lab/src/lib/utilities/query-param-state/query-param-sync.ts
@@ -1,4 +1,11 @@
-import { Service, inject } from '@angular/core';
+import {
+  DestroyRef,
+  Service,
+  WritableSignal,
+  inject,
+  signal,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
 import type { QueryParamOptions } from './query-param-types';
 
@@ -6,10 +13,49 @@ import type { QueryParamOptions } from './query-param-types';
 export class QueryParamSyncService {
   private readonly router = inject(Router);
   private readonly route = inject(ActivatedRoute);
+  private readonly destroyRef = inject(DestroyRef);
 
   private pendingParams: Record<string, string> | null = null;
   private pendingReplace = true;
   private flushScheduled = false;
+
+  /**
+   * One shared raw value per param key. Every `injectQueryParam(key)` call site
+   * observes the same signal, so a write from one is visible to all of them in
+   * the same tick instead of only after the URL round-trip.
+   */
+  private readonly rawSignals = new Map<
+    string,
+    WritableSignal<string | null>
+  >();
+
+  constructor() {
+    // A single subscription feeds every registered key, rather than one per
+    // call site.
+    this.route.queryParamMap
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((params) => {
+        for (const [key, sig] of this.rawSignals) {
+          sig.set(params.has(key) ? params.get(key) : null);
+        }
+      });
+  }
+
+  /**
+   * The shared raw value for `key`, created on first use and seeded from the
+   * live URL. Holding the *serialised string* rather than the parsed value
+   * means signal equality collapses no-op updates on its own, so parsers that
+   * return fresh objects (`parseAsJson`, `parseAsArrayOf`, the `Date` parsers)
+   * don't re-notify on every navigation.
+   */
+  raw(key: string): WritableSignal<string | null> {
+    let sig = this.rawSignals.get(key);
+    if (sig === undefined) {
+      sig = signal(this.getRaw(key));
+      this.rawSignals.set(key, sig);
+    }
+    return sig;
+  }
 
   /**
    * Read the current raw string value for `key` from the live URL.

--- a/libs/ui-lab/src/lib/utilities/query-param-state/query-param-types.ts
+++ b/libs/ui-lab/src/lib/utilities/query-param-state/query-param-types.ts
@@ -8,6 +8,13 @@ export interface Parser<T> {
 export interface QueryParamOptions {
   /** 'replace' (default) or 'push' — controls browser history behaviour */
   history?: 'replace' | 'push';
+  /**
+   * Debounce URL writes by this many milliseconds. The signal is still
+   * updated synchronously — only the navigation is delayed. Defaults to 0
+   * (writes flushed on the next microtask). Useful for inputs where the
+   * user types rapidly and you don't want a history entry per keystroke.
+   */
+  debounceMs?: number;
 }
 
 export interface ParserBuilder<T> extends Parser<T> {


### PR DESCRIPTION
…RL writes

The signal now drives the URL via an effect; set/clear no longer write to the URL directly. When debounceMs is provided, the effect reads through Angular's experimental debounced() so rapid input updates the signal immediately while the URL is updated only after the user stops typing. Default values are stripped so the URL only carries deviations.