### PR TITLE
refactor: adopt @Service decorator over @Injectable

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -69,5 +69,6 @@ You are an expert in TypeScript, Angular, and scalable web application developme
 ## Services
 
 - Design services around a single responsibility
-- Use the `providedIn: 'root'` option for singleton services
-- Use the `inject()` function instead of constructor injection
+- Use `@Service()` (Angular v22+) instead of `@Injectable({ providedIn: 'root' })` for singleton services
+- Use `@Service({ autoProvided: false })` instead of bare `@Injectable()` for services provided in a component's `providers` array
+- Use the `inject()` function instead of constructor injection. `@Service` classes MUST NOT use constructor DI — the compiler rejects it (`@Service class cannot use constructor dependency injection. Use the inject function instead.`)

--- a/apps/blocks/src/app/pages/data-table/user.service.ts
+++ b/apps/blocks/src/app/pages/data-table/user.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Service } from '@angular/core';
 
 export interface User {
   id: number;
@@ -438,7 +438,7 @@ const USERS: User[] = [
   },
 ];
 
-@Injectable({ providedIn: 'root' })
+@Service()
 export class UserService {
   getUsers(): User[] {
     return USERS;

--- a/apps/showcase/src/app/components/package-manager-install/package-manager.service.ts
+++ b/apps/showcase/src/app/components/package-manager-install/package-manager.service.ts
@@ -1,6 +1,6 @@
-import { Injectable, signal } from '@angular/core';
+import { Service, signal } from '@angular/core';
 
-@Injectable({ providedIn: 'root' })
+@Service()
 export class PackageManagerService {
   readonly selected = signal('pnpm');
 }

--- a/apps/showcase/src/app/components/toc/toc.service.ts
+++ b/apps/showcase/src/app/components/toc/toc.service.ts
@@ -1,4 +1,4 @@
-import { DestroyRef, Injectable, inject, signal } from '@angular/core';
+import { DestroyRef, Service, inject, signal } from '@angular/core';
 
 export interface TocItem {
   id: string;
@@ -6,9 +6,7 @@ export interface TocItem {
   level: number;
 }
 
-@Injectable({
-  providedIn: 'root',
-})
+@Service()
 export class TocService {
   private readonly destroyRef = inject(DestroyRef);
   private observer: IntersectionObserver | null = null;

--- a/apps/showcase/src/app/services/command-palette.service.ts
+++ b/apps/showcase/src/app/services/command-palette.service.ts
@@ -1,8 +1,6 @@
-import { Injectable, signal } from '@angular/core';
+import { Service, signal } from '@angular/core';
 
-@Injectable({
-  providedIn: 'root',
-})
+@Service()
 export class CommandPaletteService {
   readonly open = signal(false);
 

--- a/apps/showcase/src/app/services/components.service.ts
+++ b/apps/showcase/src/app/services/components.service.ts
@@ -1,11 +1,9 @@
 import { httpResource } from '@angular/common/http';
-import { Injectable, computed, inject } from '@angular/core';
+import { Service, computed, inject } from '@angular/core';
 import { ComponentItem } from '../data/components';
 import { ConfigService } from './config.service';
 
-@Injectable({
-  providedIn: 'root',
-})
+@Service()
 export class ComponentsService {
   private readonly configService = inject(ConfigService);
 

--- a/apps/showcase/src/app/services/config.service.ts
+++ b/apps/showcase/src/app/services/config.service.ts
@@ -1,13 +1,11 @@
 import { httpResource } from '@angular/common/http';
-import { Injectable, computed } from '@angular/core';
+import { Service, computed } from '@angular/core';
 
 interface AppConfig {
   devMode: boolean;
 }
 
-@Injectable({
-  providedIn: 'root',
-})
+@Service()
 export class ConfigService {
   private readonly configResource = httpResource<AppConfig>(
     () => 'config.json',

--- a/apps/showcase/src/app/services/github.service.ts
+++ b/apps/showcase/src/app/services/github.service.ts
@@ -1,9 +1,7 @@
 import { httpResource } from '@angular/common/http';
-import { Injectable, computed } from '@angular/core';
+import { Service, computed } from '@angular/core';
 
-@Injectable({
-  providedIn: 'root',
-})
+@Service()
 export class GithubService {
   private readonly repoResource = httpResource<{ stargazers_count: number }>(
     () => 'https://api.github.com/repos/gridatek/semantic-components',

--- a/libs/ui-lab/src/lib/components/emoji-picker/emoji-picker-state.ts
+++ b/libs/ui-lab/src/lib/components/emoji-picker/emoji-picker-state.ts
@@ -1,4 +1,4 @@
-import { Injectable, computed, signal } from '@angular/core';
+import { Service, computed, signal } from '@angular/core';
 
 export interface Emoji {
   emoji: string;
@@ -13,7 +13,7 @@ export interface EmojiCategory {
   emojis: Emoji[];
 }
 
-@Injectable()
+@Service({ autoProvided: false })
 export class ScEmojiPickerState {
   readonly categories = signal<EmojiCategory[]>([]);
   readonly searchQuery = signal<string>('');

--- a/libs/ui-lab/src/lib/components/image-annotator/image-annotator-state.ts
+++ b/libs/ui-lab/src/lib/components/image-annotator/image-annotator-state.ts
@@ -1,7 +1,7 @@
-import { Injectable, type Signal, computed, signal } from '@angular/core';
+import { Service, type Signal, computed, signal } from '@angular/core';
 import type { Annotation, AnnotationTool } from './image-annotator-types';
 
-@Injectable()
+@Service({ autoProvided: false })
 export class ScImageAnnotatorState {
   src!: Signal<string>;
   width!: Signal<number>;

--- a/libs/ui-lab/src/lib/components/language-switcher/language.service.ts
+++ b/libs/ui-lab/src/lib/components/language-switcher/language.service.ts
@@ -1,7 +1,7 @@
 import { DOCUMENT } from '@angular/common';
 import {
-  Injectable,
   InjectionToken,
+  Service,
   computed,
   inject,
   signal,
@@ -40,7 +40,7 @@ export const SC_LANGUAGE_CONFIG = new InjectionToken<LanguageConfig>(
   },
 );
 
-@Injectable({ providedIn: 'root' })
+@Service()
 export class ScLanguageService {
   private readonly document = inject(DOCUMENT);
   private readonly config = inject(SC_LANGUAGE_CONFIG);

--- a/libs/ui-lab/src/lib/components/mention-input/mention-input-state.ts
+++ b/libs/ui-lab/src/lib/components/mention-input/mention-input-state.ts
@@ -1,7 +1,7 @@
 import { CdkOverlayOrigin } from '@angular/cdk/overlay';
 import {
   ElementRef,
-  Injectable,
+  Service,
   type Signal,
   type WritableSignal,
   computed,
@@ -10,7 +10,7 @@ import {
 import { getCaretOffset } from './mention-input-caret';
 import type { MentionUser } from './mention-input-types';
 
-@Injectable()
+@Service({ autoProvided: false })
 export class ScMentionInputState {
   users!: Signal<MentionUser[]>;
   trigger!: Signal<string>;

--- a/libs/ui-lab/src/lib/components/spotlight/spotlight-state.ts
+++ b/libs/ui-lab/src/lib/components/spotlight/spotlight-state.ts
@@ -1,10 +1,4 @@
-import {
-  DestroyRef,
-  Injectable,
-  computed,
-  inject,
-  signal,
-} from '@angular/core';
+import { DestroyRef, Service, computed, inject, signal } from '@angular/core';
 
 export interface TargetRect {
   top: number;
@@ -15,7 +9,7 @@ export interface TargetRect {
 
 let nextMaskId = 0;
 
-@Injectable()
+@Service({ autoProvided: false })
 export class ScSpotlightState {
   private readonly destroyRef = inject(DestroyRef);
 

--- a/libs/ui-lab/src/lib/components/tour-guide/tour-guide-state.ts
+++ b/libs/ui-lab/src/lib/components/tour-guide/tour-guide-state.ts
@@ -1,8 +1,8 @@
-import { Injectable, computed, inject, signal } from '@angular/core';
+import { Service, computed, inject, signal } from '@angular/core';
 import type { TargetRect } from './tour-guide-types';
 import { TourService } from './tour-service';
 
-@Injectable()
+@Service({ autoProvided: false })
 export class ScTourGuideState {
   private readonly tourService = inject(TourService);
 

--- a/libs/ui-lab/src/lib/components/tour-guide/tour-service.ts
+++ b/libs/ui-lab/src/lib/components/tour-guide/tour-service.ts
@@ -1,7 +1,7 @@
-import { Injectable, computed, signal } from '@angular/core';
+import { Service, computed, signal } from '@angular/core';
 import type { TourOptions, TourStep } from './tour-guide-types';
 
-@Injectable({ providedIn: 'root' })
+@Service()
 export class TourService {
   private readonly _isActive = signal(false);
   private readonly _currentStep = signal(0);

--- a/libs/ui-lab/src/lib/components/transfer-list/transfer-list-state.ts
+++ b/libs/ui-lab/src/lib/components/transfer-list/transfer-list-state.ts
@@ -1,12 +1,7 @@
-import {
-  Injectable,
-  type WritableSignal,
-  computed,
-  signal,
-} from '@angular/core';
+import { Service, type WritableSignal, computed, signal } from '@angular/core';
 import type { TransferListItem } from './transfer-list-types';
 
-@Injectable()
+@Service({ autoProvided: false })
 export class ScTransferListState {
   sourceItems!: WritableSignal<TransferListItem[]>;
   targetItems!: WritableSignal<TransferListItem[]>;

--- a/libs/ui-lab/src/lib/utilities/query-param-state/query-param-sync.ts
+++ b/libs/ui-lab/src/lib/utilities/query-param-state/query-param-sync.ts
@@ -1,8 +1,8 @@
-import { Injectable, inject } from '@angular/core';
+import { Service, inject } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import type { QueryParamOptions } from './query-param-types';
 
-@Injectable({ providedIn: 'root' })
+@Service()
 export class QueryParamSyncService {
   private readonly router = inject(Router);
   private readonly route = inject(ActivatedRoute);

--- a/libs/ui/src/lib/components/sidebar/sidebar-state.ts
+++ b/libs/ui/src/lib/components/sidebar/sidebar-state.ts
@@ -1,6 +1,6 @@
-import { Injectable, computed, signal } from '@angular/core';
+import { Service, computed, signal } from '@angular/core';
 
-@Injectable()
+@Service({ autoProvided: false })
 export class ScSidebarState {
   // Signals for reactive state
   readonly open = signal(true);

--- a/libs/ui/src/lib/components/theme/theme-manager.ts
+++ b/libs/ui/src/lib/components/theme/theme-manager.ts
@@ -1,6 +1,6 @@
 import {
-  Injectable,
   InjectionToken,
+  Service,
   computed,
   effect,
   inject,
@@ -27,7 +27,7 @@ export const SC_THEME_CONFIG = new InjectionToken<Partial<ScThemeConfig>>(
   'SC_THEME_CONFIG',
 );
 
-@Injectable({ providedIn: 'root' })
+@Service()
 export class ScThemeManager {
   private readonly config = {
     ...defaultConfig,

--- a/libs/ui/src/lib/components/toast/toaster.ts
+++ b/libs/ui/src/lib/components/toast/toaster.ts
@@ -1,13 +1,11 @@
 import { _IdGenerator } from '@angular/cdk/a11y';
 import { Overlay, OverlayRef } from '@angular/cdk/overlay';
 import { ComponentPortal } from '@angular/cdk/portal';
-import { Injectable, inject, signal } from '@angular/core';
+import { Service, inject, signal } from '@angular/core';
 import { ScToastStack } from './toast-stack';
 import { ScToastConfig, ScToastData, ScToastPosition } from './toast.types';
 
-@Injectable({
-  providedIn: 'root',
-})
+@Service()
 export class ScToaster {
   private readonly toastsSignal = signal<ScToastData[]>([]);
   readonly toasts = this.toastsSignal.asReadonly();

--- a/libs/ui/src/lib/components/tooltip/tooltip-manager.ts
+++ b/libs/ui/src/lib/components/tooltip/tooltip-manager.ts
@@ -3,9 +3,9 @@ import { ComponentPortal } from '@angular/cdk/portal';
 import {
   ComponentRef,
   ElementRef,
-  Injectable,
   Injector,
   OutputRefSubscription,
+  Service,
   inject,
 } from '@angular/core';
 import { Subscription } from 'rxjs';
@@ -85,7 +85,7 @@ export interface ScTooltipConfig {
   position: ScTooltipPosition;
 }
 
-@Injectable({ providedIn: 'root' })
+@Service()
 export class ScTooltipManager {
   private readonly overlay = inject(Overlay);
   private readonly injector = inject(Injector);


### PR DESCRIPTION
Angular v22 adds `@Service`, a terser replacement for `@Injectable`:

| Before | After |
| --- | --- |
| `@Injectable({ providedIn: 'root' })` | `@Service()` |
| `@Injectable()` (listed in a component's `providers`) | `@Service({ autoProvided: false })` |

## Changes

Converted all **20 compiled call sites** — 13 to `@Service()`, 7 to `@Service({ autoProvided: false })` — and swapped the `Injectable` import specifier for `Service`.

`@Injectable` is *not* deprecated (only its `providedIn: 'any'` option is), so this is an ergonomics/consistency change rather than a forced migration. After this, `@Injectable` no longer appears in compiled code.

## Deliberately not converted

4 `@Injectable` occurrences remain, all inside template literals in the diff-viewer demo — `oldLarge`/`newLarge` in `large-diff-viewer-demo.ts` and the generated snapshot in its container. That is sample content rendered *by* the diff viewer, not compiled code, so converting it would corrupt the demo.

## The constructor-DI constraint

`@Service` forbids constructor dependency injection. This is enforced by the compiler, not convention:

```
ErrorCode.SERVICE_CONSTRUCTOR_DI
"@Service class cannot use constructor dependency injection. Use the `inject` function instead."
```

It also compiles the factory with `deps: []` hardcoded, so constructor deps are never emitted.

All converted classes already use `inject()`. Of the three constructors in scope, two (`theme-manager.ts`, `spotlight-state.ts`) take no parameters, and the only parameterized one — `constructor(private http: HttpClient)` — is inside the diff-viewer sample text, which is excluded. **No `inject()` rewrites were required.**

## Verification

| Check | Result |
| --- | --- |
| `nx run-many -t lint` | Successfully ran for 11 projects, 0 errors |
| `tsc --noEmit` — `libs/ui`, `libs/ui-lab`, `apps/showcase`, `apps/blocks` | exit 0 (all 4 affected projects) |
| Parameterized constructors in converted files | none |
| `@Injectable` left in compiled code | none |

Note that `SERVICE_CONSTRUCTOR_DI` is an **ngtsc** diagnostic, so plain `tsc --noEmit` cannot surface it — CI's `nx run-many -t build` is the Angular-aware check that would.

`.claude/CLAUDE.md` updated to prefer `@Service` and to record the constructor-DI restriction, so new services follow this and don't reintroduce constructor injection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
