### PR TITLE
chore: normalize line endings to LF via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+# Normalize line endings to LF, both in the repository and in working trees on
+# every platform.
+#
+# Without this, `core.autocrlf=true` (the Git for Windows default) checks files
+# out with CRLF. Scripts that embed file contents into generated string
+# literals — scripts/sync-demo-code.mjs, which writes the `code` property of
+# every *-demo-container.ts — then bake the \r into those literals, so
+# scripts/validate-demo-code.mjs reports mismatches that do not exist for
+# contributors on LF platforms.
+#
+# `text=auto` still lets Git detect and leave binary files untouched.
+* text=auto eol=lf
+
+# Explicitly binary, so Git never attempts line-ending conversion on them.
+*.ico binary


### PR DESCRIPTION
The repository already stores every file with LF — `git grep -Il $'\r' HEAD` returns 0 — but with no `.gitattributes`, the Git for Windows default `core.autocrlf=true` checks them out as **CRLF**.

## Why this matters

It silently breaks the demo-code tooling. `scripts/sync-demo-code.mjs` reads each `*-demo.ts` raw and embeds it in the `code` template literal of its container, so on Windows it bakes `\r` into those literals. `scripts/validate-demo-code.mjs` then reports mismatches that don't exist for anyone on an LF platform:

```
Line 1 current : "import {"
Line 1 expected: "import {\r"
Total mismatches: 34
```

Running the sync "fixes" them by rewriting 34 files with pure line-ending churn — a diff that looks real but contains no content change. This bit me twice while working on #1485 and had to be reverted both times.

## The fix

```
* text=auto eol=lf
```

This pins LF in working trees on every platform regardless of the contributor's local `core.autocrlf`. `text=auto` still lets Git detect and skip binary files; `*.ico` is marked `binary` explicitly for good measure.

## No content changes

`git add --renormalize .` staged **nothing beyond `.gitattributes` itself**, confirming the index was already LF. This commit is one new file, 15 lines. Existing checkouts pick up LF on their next `git checkout`/`reset --hard`; no history rewrite and no mass re-commit.

## Verification

Working tree refreshed locally (`git rm --cached -r . && git reset --hard`) so the new attributes actually apply, then:

| Check | Before | After |
| --- | --- | --- |
| `validate-demo-code.mjs` | Total mismatches: 34 | **Total mismatches: 0** |
| `sync-demo-code.mjs` | Updated: 34 | **Updated: 0**, Already in sync: 528 |
| Working tree after sync | 34 files modified | **clean** |
| `nx run-many -t lint` | — | Successfully ran for 11 projects, 0 errors |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
