### PR TITLE
chore: modernize the diff-viewer sample service

### DIFF
--- a/apps/showcase/src/app/pages/docs/diff-viewer/demos/large-diff-viewer-demo-container.ts
+++ b/apps/showcase/src/app/pages/docs/diff-viewer/demos/large-diff-viewer-demo-container.ts
@@ -195,7 +195,7 @@ import {
 })
 export class LargeDiffViewerDemo {
   oldLarge = \`// User Service
-import { Injectable } from '@angular/core';
+import { Service, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 
@@ -205,13 +205,10 @@ export interface User {
   email: string;
 }
 
-@Injectable({
-  providedIn: 'root'
-})
+@Service()
 export class UserService {
-  private apiUrl = '/api/users';
-
-  constructor(private http: HttpClient) {}
+  private readonly http = inject(HttpClient);
+  private readonly apiUrl = '/api/users';
 
   getUsers(): Observable<User[]> {
     return this.http.get<User[]>(this.apiUrl);
@@ -235,7 +232,7 @@ export class UserService {
 }\`;
 
   newLarge = \`// User Service - Updated
-import { Injectable, inject } from '@angular/core';
+import { Service, inject } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable, catchError, retry } from 'rxjs';
 import { environment } from '../environments/environment';
@@ -253,9 +250,7 @@ export interface UserFilters {
   search?: string;
 }
 
-@Injectable({
-  providedIn: 'root'
-})
+@Service()
 export class UserService {
   private readonly http = inject(HttpClient);
   private readonly apiUrl = environment.apiUrl + '/users';

--- a/apps/showcase/src/app/pages/docs/diff-viewer/demos/large-diff-viewer-demo.ts
+++ b/apps/showcase/src/app/pages/docs/diff-viewer/demos/large-diff-viewer-demo.ts
@@ -175,7 +175,7 @@ import {
 })
 export class LargeDiffViewerDemo {
   oldLarge = `// User Service
-import { Injectable } from '@angular/core';
+import { Service, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 
@@ -185,13 +185,10 @@ export interface User {
   email: string;
 }
 
-@Injectable({
-  providedIn: 'root'
-})
+@Service()
 export class UserService {
-  private apiUrl = '/api/users';
-
-  constructor(private http: HttpClient) {}
+  private readonly http = inject(HttpClient);
+  private readonly apiUrl = '/api/users';
 
   getUsers(): Observable<User[]> {
     return this.http.get<User[]>(this.apiUrl);
@@ -215,7 +212,7 @@ export class UserService {
 }`;
 
   newLarge = `// User Service - Updated
-import { Injectable, inject } from '@angular/core';
+import { Service, inject } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable, catchError, retry } from 'rxjs';
 import { environment } from '../environments/environment';
@@ -233,9 +230,7 @@ export interface UserFilters {
   search?: string;
 }
 
-@Injectable({
-  providedIn: 'root'
-})
+@Service()
 export class UserService {
   private readonly http = inject(HttpClient);
   private readonly apiUrl = environment.apiUrl + '/users';


### PR DESCRIPTION
The last 4 `@Injectable` occurrences in the repository lived inside the `oldLarge`/`newLarge` template literals of the diff-viewer demo, plus the generated container snapshot. They are sample text rather than compiled code — but they are shown to users as example Angular, and they contradicted the conventions the rest of the codebase adopted in #1486.

Both sides now use `@Service()` with `inject()`. **`@Injectable` no longer appears anywhere in the repo.**

## Why both sides needed the DI change too

`@Service` forbids constructor dependency injection — the compiler emits `SERVICE_CONSTRUCTOR_DI` and compiles the factory with `deps: []`. The "old" side had:

```ts
@Injectable({ providedIn: 'root' })
export class UserService {
  constructor(private http: HttpClient) {}
```

Converting only the decorator would have produced sample code that Angular actively rejects — worse than leaving it alone, since it would be teaching an invalid pattern. Both sides therefore use `private readonly http = inject(HttpClient)`.

## The demo still demonstrates a real diff

Only the decorator and DI lines are now identical across the two panes. The "after" side still adds:

- `HttpParams`-based filtering and a `UserFilters` interface
- `retry(2)` + `catchError` error handling with a `handleError` method
- an `environment`-based API URL
- `role` and `createdAt` fields on `User`
- `patch` instead of `put` for updates

## Verification

| Check | Result |
| --- | --- |
| `@Injectable` in repo | **0** |
| `prettier --check` on both files | All matched files use Prettier code style |
| `nx run-many -t lint` | Successfully ran for 11 projects, 0 errors |
| `tsc --noEmit` (`apps/showcase`) | exit 0 |
| `validate-demo-code.mjs` | Total mismatches: 0 |

The container snapshot was regenerated with `scripts/sync-demo-code.mjs` (Updated: 1) rather than hand-edited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
