### PR TITLE
docs: sweep stale OnPush and @Injectable references

### DIFF
--- a/docs/article-launch.md
+++ b/docs/article-launch.md
@@ -180,7 +180,7 @@ export class ScButton {
 This library makes deliberate choices that prioritize the future of Angular over backwards compatibility. That means it is **not for every project** — and that's intentional.
 
 - **Zoneless only.** The library is built for zoneless Angular apps.
-- **OnPush only.** All components use `ChangeDetectionStrategy.OnPush`.
+- **OnPush only.** All components use OnPush change detection, the Angular v22+ default.
 - **Signal-based forms only.** Form integrations are designed around signals, not `NgModel` or reactive forms.
 - **No NgModules.** Everything is standalone. There are no module exports, no `forRoot()`, no compatibility shims for module-based apps.
 

--- a/docs/component-design-principles.md
+++ b/docs/component-design-principles.md
@@ -203,7 +203,6 @@ import { cn } from '../../utils';
   template: `
     <ng-content />
   `,
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ScComponentName {
   // Class input for custom styling

--- a/docs/composable-architecture.md
+++ b/docs/composable-architecture.md
@@ -132,7 +132,6 @@ Container components group related sub-components and apply layout styles.
     '[attr.data-disabled]': 'component.disabled() || null',
   },
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ScComponentNameGroup {
   readonly component = inject(SC_COMPONENT_NAME);
@@ -172,7 +171,6 @@ Components that perform actions (buttons, toggles, inputs).
     '(click)': 'onClick()',
   },
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ScComponentNameAction {
   readonly component = inject(SC_COMPONENT_NAME);
@@ -212,7 +210,6 @@ Input fields that sync with parent state.
     '(input)': 'onInput($event)',
   },
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ScComponentNameInput {
   readonly component = inject(SC_COMPONENT_NAME);

--- a/docs/signal-forms-migration.md
+++ b/docs/signal-forms-migration.md
@@ -15,7 +15,7 @@ This repository uses **Angular Signal Forms** (`@angular/forms/signals`) exclusi
 Every form is a writable signal holding the model, wrapped by `form()`:
 
 ```typescript
-import { ChangeDetectionStrategy, Component, ViewEncapsulation, signal } from '@angular/core';
+import { Component, ViewEncapsulation, signal } from '@angular/core';
 import { FormField, form } from '@angular/forms/signals';
 
 @Component({
@@ -25,7 +25,6 @@ import { FormField, form } from '@angular/forms/signals';
     <input type="text" [formField]="profileForm.name" placeholder="Name" />
   `,
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class Example {
   readonly formModel = signal({ name: '' });

--- a/docs/writing-a-component-page.md
+++ b/docs/writing-a-component-page.md
@@ -33,7 +33,7 @@ Each demo is a minimal standalone component isolating one behavior.
 **File:** `demos/basic-{component}-demo.ts`
 
 ```typescript
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { Component } from '@angular/core';
 import { ScAccordion, ScAccordionItem, ScAccordionPanel, ScAccordionTrigger } from '@semantic-components/ui';
 
 @Component({
@@ -51,7 +51,6 @@ import { ScAccordion, ScAccordionItem, ScAccordionPanel, ScAccordionTrigger } fr
       </div>
     </div>
   `,
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class BasicAccordionDemo {}
 ```
@@ -69,7 +68,7 @@ Each demo gets a container that wraps it with a title and code viewer.
 **File:** `demos/basic-{component}-demo-container.ts`
 
 ```typescript
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { Component } from '@angular/core';
 import { DemoContainer } from '../../../../components/demo-container/demo-container';
 import { BasicAccordionDemo } from './basic-accordion-demo';
 
@@ -82,7 +81,6 @@ import { BasicAccordionDemo } from './basic-accordion-demo';
     </app-demo-container>
   `,
   host: { class: 'block' },
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class BasicAccordionDemoContainer {
   readonly code = `// The exact content of basic-accordion-demo.ts goes here
@@ -103,7 +101,7 @@ The page imports all containers and displays them.
 **File:** `{component}-page.ts`
 
 ```typescript
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { Component } from '@angular/core';
 import { BasicAccordionDemoContainer } from './demos/basic-accordion-demo-container';
 import { DisabledAccordionDemoContainer } from './demos/disabled-accordion-demo-container';
 import { MultipleAccordionDemoContainer } from './demos/multiple-accordion-demo-container';
@@ -126,7 +124,6 @@ import { MultipleAccordionDemoContainer } from './demos/multiple-accordion-demo-
       </section>
     </div>
   `,
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export default class AccordionPage {}
 ```

--- a/libs/ui-lab/src/lib/components/navbar/ARCHITECTURE.md
+++ b/libs/ui-lab/src/lib/components/navbar/ARCHITECTURE.md
@@ -463,7 +463,7 @@ The animation system preserves accessibility:
 
 ### Efficient Rendering
 
-- Uses `ChangeDetectionStrategy.OnPush` everywhere
+- OnPush change detection throughout (the Angular v22+ default)
 - Effects only run when dependencies change
 - No manual subscriptions to manage (except router events with cleanup)
 - Overlay reused across open/close cycles

--- a/libs/ui/src/lib/components/alert-dialog/ARCHITECTURE.md
+++ b/libs/ui/src/lib/components/alert-dialog/ARCHITECTURE.md
@@ -739,7 +739,7 @@ The animation system preserves accessibility:
 
 ### Efficient Rendering
 
-- Uses `ChangeDetectionStrategy.OnPush` everywhere
+- OnPush change detection throughout (the Angular v22+ default)
 - Effects only run when dependencies change
 - No manual subscriptions to manage
 - Single overlay instance reused

--- a/libs/ui/src/lib/components/autocomplete/README.md
+++ b/libs/ui/src/lib/components/autocomplete/README.md
@@ -58,7 +58,7 @@ A combobox-style autocomplete input with filtering, keyboard navigation, and ove
 ### Component
 
 ```typescript
-import { ChangeDetectionStrategy, Component, computed, signal } from '@angular/core';
+import { Component, computed, signal } from '@angular/core';
 import { FormField, form } from '@angular/forms/signals';
 import { ScAutocomplete, ScAutocompleteEmpty, ScAutocompleteGroup, ScAutocompleteIcon, ScAutocompleteInput, ScAutocompleteItem, ScAutocompleteItemIndicator, ScAutocompleteItemLabel, ScAutocompleteList, ScAutocompletePopup, ScAutocompletePortal } from '@semantic-components/ui';
 import { SiCheckIcon, SiSearchIcon } from '@semantic-icons/lucide-icons';
@@ -89,7 +89,6 @@ import { SiCheckIcon, SiSearchIcon } from '@semantic-icons/lucide-icons';
       </ng-template>
     </div>
   `,
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class Example {
   readonly formModel = signal({ query: '' });

--- a/libs/ui/src/lib/components/dialog/ARCHITECTURE.md
+++ b/libs/ui/src/lib/components/dialog/ARCHITECTURE.md
@@ -723,7 +723,7 @@ The animation system preserves accessibility:
 
 ### Efficient Rendering
 
-- Uses `ChangeDetectionStrategy.OnPush` everywhere
+- OnPush change detection throughout (the Angular v22+ default)
 - Effects only run when dependencies change
 - No manual subscriptions to manage
 - Single overlay instance reused

--- a/libs/ui/src/lib/components/drawer/ARCHITECTURE.md
+++ b/libs/ui/src/lib/components/drawer/ARCHITECTURE.md
@@ -796,7 +796,7 @@ The animation system preserves accessibility:
 
 ### Efficient Rendering
 
-- Uses `ChangeDetectionStrategy.OnPush` everywhere
+- OnPush change detection throughout (the Angular v22+ default)
 - Effects only run when dependencies change
 - No manual subscriptions to manage
 - Single overlay instance reused

--- a/libs/ui/src/lib/components/select/README.md
+++ b/libs/ui/src/lib/components/select/README.md
@@ -106,7 +106,7 @@ Use `ScSelectGroup`, `ScSelectGroupLabel`, and `ScSelectSeparator` to organize o
 ### Component
 
 ```typescript
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { Component } from '@angular/core';
 import { ScSelect, ScSelectInput, ScSelectItem, ScSelectItemIcon, ScSelectItemLabel, ScSelectList, ScSelectOrigin, ScSelectPopup, ScSelectPortal } from '@semantic-components/ui';
 
 @Component({
@@ -130,7 +130,6 @@ import { ScSelect, ScSelectInput, ScSelectItem, ScSelectItemIcon, ScSelectItemLa
       </ng-template>
     </div>
   `,
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class Example {
   options = [

--- a/libs/ui/src/lib/components/sheet/ARCHITECTURE.md
+++ b/libs/ui/src/lib/components/sheet/ARCHITECTURE.md
@@ -753,7 +753,7 @@ The animation system preserves accessibility:
 
 ### Efficient Rendering
 
-- Uses `ChangeDetectionStrategy.OnPush` everywhere
+- OnPush change detection throughout (the Angular v22+ default)
 - Effects only run when dependencies change
 - No manual subscriptions to manage
 - Single overlay instance reused

--- a/libs/ui/src/lib/components/toast/README.md
+++ b/libs/ui/src/lib/components/toast/README.md
@@ -36,7 +36,7 @@ ScToaster (Injectable)
 ### ScToaster
 
 ```typescript
-@Injectable({ providedIn: 'root' })
+@Service()
 class ScToaster {
   // Signal containing all active toasts
   readonly toasts: Signal<ToastData[]>;


### PR DESCRIPTION
The codemods in #1485 (drop `OnPush`) and #1486 (adopt `@Service`) only ever ran over `*.ts`. The markdown documentation was never touched, so it still teaches the pre-v22 idioms.

## Changes

| Category | Count | Change |
| --- | --- | --- |
| `changeDetection:` lines in example code blocks | 10 | removed — it is the v22+ default |
| `ChangeDetectionStrategy` import specifiers | 6 | dropped from the import |
| Prose claims | 6 | reworded |
| `@Injectable` in the toast README | 1 | → `@Service()` |

The prose rewording keeps the meaning — the components *are* OnPush — while dropping the implication that it is declared explicitly:

```diff
-- Uses `ChangeDetectionStrategy.OnPush` everywhere
+- OnPush change detection throughout (the Angular v22+ default)
```

`libs/ui/src/lib/components/toast/README.md` is the one that mattered most: it documented `ScToaster` as `@Injectable({ providedIn: 'root' })`, but the shipped class became `@Service()` in #1486. That was describing the public API **incorrectly**, not just using a dated style.

## Deliberately left alone

- **`.claude/CLAUDE.md`** lines 40 and 72–73 name `ChangeDetectionStrategy` and `@Injectable` on purpose — they are the "use X instead of Y" guidance, and stripping the old name would make the rules unreadable.
- **`docs/declarative-architecture.md`** keeps `constructor(private dialog: MatDialog)` at lines 16 and 333. It sits under a heading reading **"Imperative (Traditional):"** — a labelled contrast example — and it uses Angular Material rather than this library.

## Verification

- `prettier --check` on all 13 changed files: clean
- Remaining `ChangeDetectionStrategy` in markdown: 1, the intentional `CLAUDE.md` rule
- Remaining `@Injectable` anywhere in the repo: 2, both the intentional `CLAUDE.md` guidance

Docs-only; no compiled code is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
