### PR TITLE
style: format e2e specs with Prettier

### DIFF
--- a/apps/showcase-e2e/src/pages/accordion-page.spec.ts
+++ b/apps/showcase-e2e/src/pages/accordion-page.spec.ts
@@ -1,5 +1,4 @@
 import { test } from '@playwright/test';
-
 import { expectNoA11yViolations } from '../axe';
 
 test.describe('Accordion Page', () => {

--- a/apps/showcase-e2e/src/pages/alert-dialog-page.spec.ts
+++ b/apps/showcase-e2e/src/pages/alert-dialog-page.spec.ts
@@ -1,5 +1,4 @@
 import { test } from '@playwright/test';
-
 import { expectNoA11yViolations } from '../axe';
 
 test.describe('Alert Dialog Page', () => {

--- a/apps/showcase-e2e/src/pages/alert-page.spec.ts
+++ b/apps/showcase-e2e/src/pages/alert-page.spec.ts
@@ -1,5 +1,4 @@
 import { test } from '@playwright/test';
-
 import { expectNoA11yViolations } from '../axe';
 
 test.describe('Alert Page', () => {

--- a/apps/showcase-e2e/src/pages/aspect-ratio-page.spec.ts
+++ b/apps/showcase-e2e/src/pages/aspect-ratio-page.spec.ts
@@ -1,5 +1,4 @@
 import { test } from '@playwright/test';
-
 import { expectNoA11yViolations } from '../axe';
 
 test.describe('Aspect Ratio Page', () => {

--- a/apps/showcase-e2e/src/pages/audio-player-page.spec.ts
+++ b/apps/showcase-e2e/src/pages/audio-player-page.spec.ts
@@ -1,5 +1,4 @@
 import { test } from '@playwright/test';
-
 import { expectNoA11yViolations } from '../axe';
 
 test.describe('Audio Player Page', () => {

--- a/apps/showcase-e2e/src/pages/avatar-page.spec.ts
+++ b/apps/showcase-e2e/src/pages/avatar-page.spec.ts
@@ -1,5 +1,4 @@
 import { test } from '@playwright/test';
-
 import { expectNoA11yViolations } from '../axe';
 
 test.describe('Avatar Page', () => {

--- a/apps/showcase-e2e/src/pages/badge-page.spec.ts
+++ b/apps/showcase-e2e/src/pages/badge-page.spec.ts
@@ -1,5 +1,4 @@
 import { test } from '@playwright/test';
-
 import { expectNoA11yViolations } from '../axe';
 
 test.describe('Badge Page', () => {

--- a/apps/showcase-e2e/src/pages/breadcrumb-page.spec.ts
+++ b/apps/showcase-e2e/src/pages/breadcrumb-page.spec.ts
@@ -1,5 +1,4 @@
 import { test } from '@playwright/test';
-
 import { expectNoA11yViolations } from '../axe';
 
 test.describe('Breadcrumb Page', () => {

--- a/apps/showcase-e2e/src/pages/button-group-page.spec.ts
+++ b/apps/showcase-e2e/src/pages/button-group-page.spec.ts
@@ -1,5 +1,4 @@
 import { test } from '@playwright/test';
-
 import { expectNoA11yViolations } from '../axe';
 
 test.describe('Button Group Page', () => {

--- a/apps/showcase-e2e/src/pages/button-page.spec.ts
+++ b/apps/showcase-e2e/src/pages/button-page.spec.ts
@@ -1,5 +1,4 @@
 import { test } from '@playwright/test';
-
 import { expectNoA11yViolations } from '../axe';
 
 test.describe('Button Page', () => {

--- a/apps/showcase-e2e/src/pages/calendar-page.spec.ts
+++ b/apps/showcase-e2e/src/pages/calendar-page.spec.ts
@@ -1,5 +1,4 @@
 import { test } from '@playwright/test';
-
 import { expectNoA11yViolations } from '../axe';
 
 test.describe('Calendar Page', () => {

--- a/apps/showcase-e2e/src/pages/card-page.spec.ts
+++ b/apps/showcase-e2e/src/pages/card-page.spec.ts
@@ -1,5 +1,4 @@
 import { test } from '@playwright/test';
-
 import { expectNoA11yViolations } from '../axe';
 
 test.describe('Card Page', () => {

--- a/apps/showcase-e2e/src/pages/carousel-page.spec.ts
+++ b/apps/showcase-e2e/src/pages/carousel-page.spec.ts
@@ -1,5 +1,4 @@
 import { test } from '@playwright/test';
-
 import { expectNoA11yViolations } from '../axe';
 
 test.describe('Carousel Page', () => {

--- a/apps/showcase-e2e/src/pages/checkbox-page.spec.ts
+++ b/apps/showcase-e2e/src/pages/checkbox-page.spec.ts
@@ -1,5 +1,4 @@
 import { test } from '@playwright/test';
-
 import { expectNoA11yViolations } from '../axe';
 
 test.describe('Checkbox Page', () => {

--- a/apps/showcase-e2e/src/pages/collapsible-page.spec.ts
+++ b/apps/showcase-e2e/src/pages/collapsible-page.spec.ts
@@ -1,5 +1,4 @@
 import { test } from '@playwright/test';
-
 import { expectNoA11yViolations } from '../axe';
 
 test.describe('Collapsible Page', () => {

--- a/apps/showcase-e2e/src/pages/dialog-page.spec.ts
+++ b/apps/showcase-e2e/src/pages/dialog-page.spec.ts
@@ -1,5 +1,4 @@
 import { test } from '@playwright/test';
-
 import { expectNoA11yViolations } from '../axe';
 
 test.describe('Dialog Page', () => {

--- a/apps/showcase-e2e/src/pages/drawer-page.spec.ts
+++ b/apps/showcase-e2e/src/pages/drawer-page.spec.ts
@@ -1,5 +1,4 @@
 import { test } from '@playwright/test';
-
 import { expectNoA11yViolations } from '../axe';
 
 test.describe('Drawer Page', () => {

--- a/apps/showcase-e2e/src/pages/empty-page.spec.ts
+++ b/apps/showcase-e2e/src/pages/empty-page.spec.ts
@@ -1,5 +1,4 @@
 import { test } from '@playwright/test';
-
 import { expectNoA11yViolations } from '../axe';
 
 test.describe('Empty Page', () => {

--- a/apps/showcase-e2e/src/pages/file-upload-page.spec.ts
+++ b/apps/showcase-e2e/src/pages/file-upload-page.spec.ts
@@ -1,5 +1,4 @@
 import { test } from '@playwright/test';
-
 import { expectNoA11yViolations } from '../axe';
 
 test.describe('File Upload Page', () => {

--- a/apps/showcase-e2e/src/pages/hover-card-page.spec.ts
+++ b/apps/showcase-e2e/src/pages/hover-card-page.spec.ts
@@ -1,5 +1,4 @@
 import { test } from '@playwright/test';
-
 import { expectNoA11yViolations } from '../axe';
 
 test.describe('Hover Card Page', () => {

--- a/apps/showcase-e2e/src/pages/image-compare-page.spec.ts
+++ b/apps/showcase-e2e/src/pages/image-compare-page.spec.ts
@@ -1,5 +1,4 @@
 import { test } from '@playwright/test';
-
 import { expectNoA11yViolations } from '../axe';
 
 test.describe('Image Compare Page', () => {

--- a/apps/showcase-e2e/src/pages/image-cropper-page.spec.ts
+++ b/apps/showcase-e2e/src/pages/image-cropper-page.spec.ts
@@ -1,5 +1,4 @@
 import { test } from '@playwright/test';
-
 import { expectNoA11yViolations } from '../axe';
 
 test.describe('Image Cropper Page', () => {

--- a/apps/showcase-e2e/src/pages/input-group-page.spec.ts
+++ b/apps/showcase-e2e/src/pages/input-group-page.spec.ts
@@ -1,5 +1,4 @@
 import { test } from '@playwright/test';
-
 import { expectNoA11yViolations } from '../axe';
 
 test.describe('Input Group Page', () => {

--- a/apps/showcase-e2e/src/pages/input-page.spec.ts
+++ b/apps/showcase-e2e/src/pages/input-page.spec.ts
@@ -1,5 +1,4 @@
 import { test } from '@playwright/test';
-
 import { expectNoA11yViolations } from '../axe';
 
 test.describe('Input Page', () => {

--- a/apps/showcase-e2e/src/pages/item-page.spec.ts
+++ b/apps/showcase-e2e/src/pages/item-page.spec.ts
@@ -1,5 +1,4 @@
 import { test } from '@playwright/test';
-
 import { expectNoA11yViolations } from '../axe';
 
 test.describe('Item Page', () => {

--- a/apps/showcase-e2e/src/pages/kbd-page.spec.ts
+++ b/apps/showcase-e2e/src/pages/kbd-page.spec.ts
@@ -1,5 +1,4 @@
 import { test } from '@playwright/test';
-
 import { expectNoA11yViolations } from '../axe';
 
 test.describe('Kbd Page', () => {

--- a/apps/showcase-e2e/src/pages/label-page.spec.ts
+++ b/apps/showcase-e2e/src/pages/label-page.spec.ts
@@ -1,5 +1,4 @@
 import { test } from '@playwright/test';
-
 import { expectNoA11yViolations } from '../axe';
 
 test.describe('Label Page', () => {

--- a/apps/showcase-e2e/src/pages/link-page.spec.ts
+++ b/apps/showcase-e2e/src/pages/link-page.spec.ts
@@ -1,5 +1,4 @@
 import { test } from '@playwright/test';
-
 import { expectNoA11yViolations } from '../axe';
 
 test.describe('Link Page', () => {

--- a/apps/showcase-e2e/src/pages/menu-bar-page.spec.ts
+++ b/apps/showcase-e2e/src/pages/menu-bar-page.spec.ts
@@ -1,5 +1,4 @@
 import { test } from '@playwright/test';
-
 import { expectNoA11yViolations } from '../axe';
 
 test.describe('Menu Bar Page', () => {

--- a/apps/showcase-e2e/src/pages/menu-page.spec.ts
+++ b/apps/showcase-e2e/src/pages/menu-page.spec.ts
@@ -1,5 +1,4 @@
 import { test } from '@playwright/test';
-
 import { expectNoA11yViolations } from '../axe';
 
 test.describe('Menu Page', () => {

--- a/apps/showcase-e2e/src/pages/native-select-page.spec.ts
+++ b/apps/showcase-e2e/src/pages/native-select-page.spec.ts
@@ -1,5 +1,4 @@
 import { test } from '@playwright/test';
-
 import { expectNoA11yViolations } from '../axe';
 
 test.describe('Native Select Page', () => {

--- a/apps/showcase-e2e/src/pages/navigation-menu-page.spec.ts
+++ b/apps/showcase-e2e/src/pages/navigation-menu-page.spec.ts
@@ -1,5 +1,4 @@
 import { test } from '@playwright/test';
-
 import { expectNoA11yViolations } from '../axe';
 
 test.describe('Navigation Menu Page', () => {

--- a/apps/showcase-e2e/src/pages/pagination-page.spec.ts
+++ b/apps/showcase-e2e/src/pages/pagination-page.spec.ts
@@ -1,5 +1,4 @@
 import { test } from '@playwright/test';
-
 import { expectNoA11yViolations } from '../axe';
 
 test.describe('Pagination Page', () => {

--- a/apps/showcase-e2e/src/pages/popover-page.spec.ts
+++ b/apps/showcase-e2e/src/pages/popover-page.spec.ts
@@ -1,5 +1,4 @@
 import { test } from '@playwright/test';
-
 import { expectNoA11yViolations } from '../axe';
 
 test.describe('Popover Page', () => {

--- a/apps/showcase-e2e/src/pages/progress-page.spec.ts
+++ b/apps/showcase-e2e/src/pages/progress-page.spec.ts
@@ -1,5 +1,4 @@
 import { test } from '@playwright/test';
-
 import { expectNoA11yViolations } from '../axe';
 
 test.describe('Progress Page', () => {

--- a/apps/showcase-e2e/src/pages/radio-group-page.spec.ts
+++ b/apps/showcase-e2e/src/pages/radio-group-page.spec.ts
@@ -1,5 +1,4 @@
 import { test } from '@playwright/test';
-
 import { expectNoA11yViolations } from '../axe';
 
 test.describe('Radio Group Page', () => {

--- a/apps/showcase-e2e/src/pages/range-slider-page.spec.ts
+++ b/apps/showcase-e2e/src/pages/range-slider-page.spec.ts
@@ -1,5 +1,4 @@
 import { test } from '@playwright/test';
-
 import { expectNoA11yViolations } from '../axe';
 
 test.describe('Range Slider Page', () => {

--- a/apps/showcase-e2e/src/pages/resizable-page.spec.ts
+++ b/apps/showcase-e2e/src/pages/resizable-page.spec.ts
@@ -1,5 +1,4 @@
 import { test } from '@playwright/test';
-
 import { expectNoA11yViolations } from '../axe';
 
 test.describe('Resizable Page', () => {

--- a/apps/showcase-e2e/src/pages/scroll-area-page.spec.ts
+++ b/apps/showcase-e2e/src/pages/scroll-area-page.spec.ts
@@ -1,5 +1,4 @@
 import { test } from '@playwright/test';
-
 import { expectNoA11yViolations } from '../axe';
 
 test.describe('Scroll Area Page', () => {

--- a/apps/showcase-e2e/src/pages/select-page.spec.ts
+++ b/apps/showcase-e2e/src/pages/select-page.spec.ts
@@ -1,5 +1,4 @@
 import { test } from '@playwright/test';
-
 import { expectNoA11yViolations } from '../axe';
 
 test.describe('Select Page', () => {

--- a/apps/showcase-e2e/src/pages/separator-page.spec.ts
+++ b/apps/showcase-e2e/src/pages/separator-page.spec.ts
@@ -1,5 +1,4 @@
 import { test } from '@playwright/test';
-
 import { expectNoA11yViolations } from '../axe';
 
 test.describe('Separator Page', () => {

--- a/apps/showcase-e2e/src/pages/sheet-page.spec.ts
+++ b/apps/showcase-e2e/src/pages/sheet-page.spec.ts
@@ -1,5 +1,4 @@
 import { test } from '@playwright/test';
-
 import { expectNoA11yViolations } from '../axe';
 
 test.describe('Sheet Page', () => {

--- a/apps/showcase-e2e/src/pages/signature-pad-page.spec.ts
+++ b/apps/showcase-e2e/src/pages/signature-pad-page.spec.ts
@@ -1,5 +1,4 @@
 import { test } from '@playwright/test';
-
 import { expectNoA11yViolations } from '../axe';
 
 test.describe('Signature Pad Page', () => {

--- a/apps/showcase-e2e/src/pages/skeleton-page.spec.ts
+++ b/apps/showcase-e2e/src/pages/skeleton-page.spec.ts
@@ -1,5 +1,4 @@
 import { test } from '@playwright/test';
-
 import { expectNoA11yViolations } from '../axe';
 
 test.describe('Skeleton Page', () => {

--- a/apps/showcase-e2e/src/pages/slider-page.spec.ts
+++ b/apps/showcase-e2e/src/pages/slider-page.spec.ts
@@ -1,5 +1,4 @@
 import { test } from '@playwright/test';
-
 import { expectNoA11yViolations } from '../axe';
 
 test.describe('Slider Page', () => {

--- a/apps/showcase-e2e/src/pages/spinner-page.spec.ts
+++ b/apps/showcase-e2e/src/pages/spinner-page.spec.ts
@@ -1,5 +1,4 @@
 import { test } from '@playwright/test';
-
 import { expectNoA11yViolations } from '../axe';
 
 test.describe('Spinner Page', () => {

--- a/apps/showcase-e2e/src/pages/switch-page.spec.ts
+++ b/apps/showcase-e2e/src/pages/switch-page.spec.ts
@@ -1,5 +1,4 @@
 import { test } from '@playwright/test';
-
 import { expectNoA11yViolations } from '../axe';
 
 test.describe('Switch Page', () => {

--- a/apps/showcase-e2e/src/pages/table-page.spec.ts
+++ b/apps/showcase-e2e/src/pages/table-page.spec.ts
@@ -1,5 +1,4 @@
 import { test } from '@playwright/test';
-
 import { expectNoA11yViolations } from '../axe';
 
 test.describe('Table Page', () => {

--- a/apps/showcase-e2e/src/pages/tabs-page.spec.ts
+++ b/apps/showcase-e2e/src/pages/tabs-page.spec.ts
@@ -1,5 +1,4 @@
 import { test } from '@playwright/test';
-
 import { expectNoA11yViolations } from '../axe';
 
 test.describe('Tabs Page', () => {

--- a/apps/showcase-e2e/src/pages/textarea-page.spec.ts
+++ b/apps/showcase-e2e/src/pages/textarea-page.spec.ts
@@ -1,5 +1,4 @@
 import { test } from '@playwright/test';
-
 import { expectNoA11yViolations } from '../axe';
 
 test.describe('Textarea Page', () => {

--- a/apps/showcase-e2e/src/pages/time-picker-clock-page.spec.ts
+++ b/apps/showcase-e2e/src/pages/time-picker-clock-page.spec.ts
@@ -1,5 +1,4 @@
 import { test } from '@playwright/test';
-
 import { expectNoA11yViolations } from '../axe';
 
 test.describe('Time Picker Clock Page', () => {

--- a/apps/showcase-e2e/src/pages/time-picker-page.spec.ts
+++ b/apps/showcase-e2e/src/pages/time-picker-page.spec.ts
@@ -1,5 +1,4 @@
 import { test } from '@playwright/test';
-
 import { expectNoA11yViolations } from '../axe';
 
 test.describe('Time Picker Page', () => {

--- a/apps/showcase-e2e/src/pages/toast-page.spec.ts
+++ b/apps/showcase-e2e/src/pages/toast-page.spec.ts
@@ -1,5 +1,4 @@
 import { test } from '@playwright/test';
-
 import { expectNoA11yViolations } from '../axe';
 
 test.describe('Toast Page', () => {

--- a/apps/showcase-e2e/src/pages/toggle-group-page.spec.ts
+++ b/apps/showcase-e2e/src/pages/toggle-group-page.spec.ts
@@ -1,5 +1,4 @@
 import { test } from '@playwright/test';
-
 import { expectNoA11yViolations } from '../axe';
 
 test.describe('Toggle Group Page', () => {

--- a/apps/showcase-e2e/src/pages/toggle-page.spec.ts
+++ b/apps/showcase-e2e/src/pages/toggle-page.spec.ts
@@ -1,5 +1,4 @@
 import { test } from '@playwright/test';
-
 import { expectNoA11yViolations } from '../axe';
 
 test.describe('Toggle Page', () => {

--- a/apps/showcase-e2e/src/pages/toolbar-page.spec.ts
+++ b/apps/showcase-e2e/src/pages/toolbar-page.spec.ts
@@ -1,5 +1,4 @@
 import { test } from '@playwright/test';
-
 import { expectNoA11yViolations } from '../axe';
 
 test.describe('Toolbar Page', () => {

--- a/apps/showcase-e2e/src/pages/tooltip-page.spec.ts
+++ b/apps/showcase-e2e/src/pages/tooltip-page.spec.ts
@@ -1,5 +1,4 @@
 import { test } from '@playwright/test';
-
 import { expectNoA11yViolations } from '../axe';
 
 test.describe('Tooltip Page', () => {

--- a/apps/showcase-e2e/src/pages/typography-page.spec.ts
+++ b/apps/showcase-e2e/src/pages/typography-page.spec.ts
@@ -1,5 +1,4 @@
 import { test } from '@playwright/test';
-
 import { expectNoA11yViolations } from '../axe';
 
 test.describe('Typography Page', () => {

--- a/apps/showcase-e2e/src/pages/video-player-page.spec.ts
+++ b/apps/showcase-e2e/src/pages/video-player-page.spec.ts
@@ -1,5 +1,4 @@
 import { test } from '@playwright/test';
-
 import { expectNoA11yViolations } from '../axe';
 
 test.describe('Video Player Page', () => {


### PR DESCRIPTION
59 e2e spec files carried a stray blank line between the `@playwright/test` import and the local `../axe` import, which Prettier's import handling removes:

```diff
 import { test } from '@playwright/test';
-
 import { expectNoA11yViolations } from '../axe';
```

These were deliberately excluded from #1485 — running Prettier across `apps/**` there pulled in 59 files beyond that codemod's scope, so I reverted them to keep a 1445-file diff free of unrelated churn. Sweeping them now closes that loose end.

## Purely mechanical

- **59 deletions, 0 insertions**
- Every removed line was blank; no other line in any file was touched (verified with `git diff -U0`)
- No behaviour change — these are formatting-only edits to test files

## Verification

| Check | Result |
| --- | --- |
| `prettier --check` on e2e projects | All matched files use Prettier code style |
| `prettier --check` on `apps/**/*.ts` + `libs/**/*.ts` | **All matched files use Prettier code style** |
| `nx run-many -t lint` | Successfully ran for 11 projects, 0 errors |

The second row is the useful side effect: with these 59 files fixed, `prettier --check` is now clean across the **entire repository**, so formatting drift can no longer hide in the e2e projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
