### PR TITLE
chore: upgrade pdfjs-dist to 6

### DIFF
--- a/libs/ui-lab/src/lib/components/pdf-viewer/pdf-viewer-root.ts
+++ b/libs/ui-lab/src/lib/components/pdf-viewer/pdf-viewer-root.ts
@@ -196,7 +196,7 @@ export class ScPdfViewerRoot {
 
     this.destroyRef.onDestroy(() => {
       document.removeEventListener('fullscreenchange', handleFullscreenChange);
-      this.pdfDocument()?.destroy();
+      this.pdfDocument()?.loadingTask.destroy();
       if (this.undoTimeout) {
         clearTimeout(this.undoTimeout);
       }
@@ -219,9 +219,9 @@ export class ScPdfViewerRoot {
 
     try {
       // Destroy previous document if any
-      this.pdfDocument()?.destroy();
+      this.pdfDocument()?.loadingTask.destroy();
 
-      const loadingTask = getDocument(url);
+      const loadingTask = getDocument({ url });
 
       // Handle password-protected PDFs
       loadingTask.onPassword = (

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "express": "^5.2.1",
         "libphonenumber-js": "^1.13.10",
         "motion": "^12.43.0",
-        "pdfjs-dist": "^5.7.284",
+        "pdfjs-dist": "^6.2.108",
         "rxjs": "^7.8.2",
         "shadcn": "^4.16.1",
         "shiki": "^4.4.1",
@@ -7806,9 +7806,9 @@
       ]
     },
     "node_modules/@napi-rs/canvas": {
-      "version": "0.1.100",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.100.tgz",
-      "integrity": "sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-1.0.3.tgz",
+      "integrity": "sha512-OlI657a5XXvKGFX7kNeIzJ8rO7IXt87Mqu2H8rXE46viAuOfum/JA7ysX7+eBhxNKznT+RCZh418mndlcFX3+w==",
       "license": "MIT",
       "optional": true,
       "workspaces": [
@@ -7822,23 +7822,23 @@
         "url": "https://github.com/sponsors/Brooooooklyn"
       },
       "optionalDependencies": {
-        "@napi-rs/canvas-android-arm64": "0.1.100",
-        "@napi-rs/canvas-darwin-arm64": "0.1.100",
-        "@napi-rs/canvas-darwin-x64": "0.1.100",
-        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.100",
-        "@napi-rs/canvas-linux-arm64-gnu": "0.1.100",
-        "@napi-rs/canvas-linux-arm64-musl": "0.1.100",
-        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.100",
-        "@napi-rs/canvas-linux-x64-gnu": "0.1.100",
-        "@napi-rs/canvas-linux-x64-musl": "0.1.100",
-        "@napi-rs/canvas-win32-arm64-msvc": "0.1.100",
-        "@napi-rs/canvas-win32-x64-msvc": "0.1.100"
+        "@napi-rs/canvas-android-arm64": "1.0.3",
+        "@napi-rs/canvas-darwin-arm64": "1.0.3",
+        "@napi-rs/canvas-darwin-x64": "1.0.3",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "1.0.3",
+        "@napi-rs/canvas-linux-arm64-gnu": "1.0.3",
+        "@napi-rs/canvas-linux-arm64-musl": "1.0.3",
+        "@napi-rs/canvas-linux-riscv64-gnu": "1.0.3",
+        "@napi-rs/canvas-linux-x64-gnu": "1.0.3",
+        "@napi-rs/canvas-linux-x64-musl": "1.0.3",
+        "@napi-rs/canvas-win32-arm64-msvc": "1.0.3",
+        "@napi-rs/canvas-win32-x64-msvc": "1.0.3"
       }
     },
     "node_modules/@napi-rs/canvas-android-arm64": {
-      "version": "0.1.100",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.100.tgz",
-      "integrity": "sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-7kSCdUhoXiO+AaIMXdBGdtp6EctZNkmF62Rea/BmVQlwKaM3bBhOzyGUzxyxz9dv5vdBfpyAaxhSRSJF4kqK4A==",
       "cpu": [
         "arm64"
       ],
@@ -7856,9 +7856,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-darwin-arm64": {
-      "version": "0.1.100",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.100.tgz",
-      "integrity": "sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-ds14V1BPagLszQyaDTeggny5fNeTCqsUQ5QhFj9VDxSEfzrVxXtdbR0LoFyKa0Siaaw8KvqSk4t7k/WoZJwvbg==",
       "cpu": [
         "arm64"
       ],
@@ -7876,9 +7876,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-darwin-x64": {
-      "version": "0.1.100",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.100.tgz",
-      "integrity": "sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-qof3LRAAycmkV2I1izZo9RoSHF8kCQr5O05sFwv0jK8rSdYV6KHVwimo6Qb7RxZj40WHKbLHm5JDaUF0o5XUAA==",
       "cpu": [
         "x64"
       ],
@@ -7896,9 +7896,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
-      "version": "0.1.100",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.100.tgz",
-      "integrity": "sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-FU2kKZLmolHA9+KcUA+l1+xH3WTLUUTQDU/kLv9SEUr2TrRPu94aytOeizFJDHPs/QBcw4QL1mCQhetQXYBbag==",
       "cpu": [
         "arm"
       ],
@@ -7916,9 +7916,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
-      "version": "0.1.100",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.100.tgz",
-      "integrity": "sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-GVSjntxKeA+/y/ZKf1F+cmUw1WeIkE5aMRPqnZUlBTBvBcrvgWccJAWuYCKPX4QJQwZILIIwhgdAbl51yj6fpA==",
       "cpu": [
         "arm64"
       ],
@@ -7936,9 +7936,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-linux-arm64-musl": {
-      "version": "0.1.100",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.100.tgz",
-      "integrity": "sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-J51oK/axyZ13kxycumSMfLiDZMdWdOVvqDFI28BpuViZHE3A0bQfr8B5vg8YnPEnqLD3BSn1hkdlh2buspEcNQ==",
       "cpu": [
         "arm64"
       ],
@@ -7956,9 +7956,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
-      "version": "0.1.100",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.100.tgz",
-      "integrity": "sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-1.0.3.tgz",
+      "integrity": "sha512-CtQgQjoVTX67jS9XuCTtJ40Sl7wRLMguoFnnGnfDmCWf7kzKFZVwj5ynqUOIGKFMSB61ZCuQlwPvVNxYTTseaw==",
       "cpu": [
         "riscv64"
       ],
@@ -7976,9 +7976,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-linux-x64-gnu": {
-      "version": "0.1.100",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.100.tgz",
-      "integrity": "sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jtfzAHFp+FRaR7zGT4jyCe6wUgAG/dVb5A4Apd8FY9jKarntDfUAlJXscugiH7ZF5kKnu7/lHFk9LaDPcrGEVQ==",
       "cpu": [
         "x64"
       ],
@@ -7996,9 +7996,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-linux-x64-musl": {
-      "version": "0.1.100",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.100.tgz",
-      "integrity": "sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-xTzaUCKUHTY4bCGadeeRZggbRVbGUT1petg7Z8r9AJR2+D9Bqu6nQAgqBGC6D47tA70LjaaaLTrJ7wNY1T74dg==",
       "cpu": [
         "x64"
       ],
@@ -8016,9 +8016,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
-      "version": "0.1.100",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.100.tgz",
-      "integrity": "sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-ktVLuBkI6QVOm5BwO/WbdGwxgeetAMJa7TTmR8qBarXF0OU2NKjvjUtPJAl2y8t+zBRczJl/1VOl9gua6WcK2g==",
       "cpu": [
         "arm64"
       ],
@@ -8036,9 +8036,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-win32-x64-msvc": {
-      "version": "0.1.100",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.100.tgz",
-      "integrity": "sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-SGhlQ8bDjL1Cz2KnsKMasr/5sTcwG/SZkB6WCJxLsmSm/3aS2C+3p39bA7iZ2/94+NkVDySZfbiGoaSZSFHYxA==",
       "cpu": [
         "x64"
       ],
@@ -24015,15 +24015,15 @@
       "license": "MIT"
     },
     "node_modules/pdfjs-dist": {
-      "version": "5.7.284",
-      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.7.284.tgz",
-      "integrity": "sha512-h4EdYQczmGhbOlqc3PPZwxevn7ApdWPbovAuWXOB/DjIyigSnwfy2oze7c6mRcSr9XgLp3eN3EeL4DyySTPMFw==",
+      "version": "6.2.108",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-6.2.108.tgz",
+      "integrity": "sha512-YxFb+SQcodN2rnX9Tn3dHYlqfb7NjlzzfONPpJd+AKoKtUjEdevTfbC07d5TcczzOK6261auRkP/M8OBHs9vFQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=22.13.0 || >=24"
       },
       "optionalDependencies": {
-        "@napi-rs/canvas": "^0.1.100"
+        "@napi-rs/canvas": "^1.0.0"
       }
     },
     "node_modules/peek-stream": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "express": "^5.2.1",
     "libphonenumber-js": "^1.13.10",
     "motion": "^12.43.0",
-    "pdfjs-dist": "^5.7.284",
+    "pdfjs-dist": "^6.2.108",
     "rxjs": "^7.8.2",
     "shadcn": "^4.16.1",
     "shiki": "^4.4.1",


### PR DESCRIPTION
Major bump, **5.7.284 → 6.2.108**. Unlike lint-staged 17 and shiki 4, this one has **real breaking changes** — the typecheck caught three:

```
pdf-viewer-root.ts(199,27) TS2339  'destroy' does not exist on type 'PDFDocumentProxy'
pdf-viewer-root.ts(222,27) TS2339  'destroy' does not exist on type 'PDFDocumentProxy'
pdf-viewer-root.ts(224,39) TS2559  Type 'string' has no properties in common
                                   with type 'DocumentInitParameters'
```

v6 removed `PDFDocumentProxy.destroy()` and dropped the string shorthand from `getDocument()`.

## Migration

```diff
-this.pdfDocument()?.destroy();
+this.pdfDocument()?.loadingTask.destroy();

-const loadingTask = getDocument(url);
+const loadingTask = getDocument({ url });
```

Three call sites in `pdf-viewer-root.ts`. No other file uses the affected APIs.

## The peer-dependency constraint

`libs/ui-lab` **publishes** `pdfjs-dist: ">=4.0.0"` as a peer dependency, so the replacement calls had to keep working on older majors — a v6-only fix would silently break consumers on v4/v5 who satisfy the declared range.

I checked the published type definitions rather than assuming:

| | `getDocument` accepts | `loadingTask` getter |
| --- | --- | --- |
| **v4.10.38** | `string \| URL \| TypedArray \| ArrayBuffer \| DocumentInitParameters` | yes |
| **v5.7.284** | same | yes |
| **v6.2.108** | `DocumentInitParameters` only | yes |

Both replacements work on v4, v5 and v6. **The peer range stays accurate and is unchanged.**

## Worker URL still resolves

The component builds its worker path from the `version` export:

```ts
GlobalWorkerOptions.workerSrc =
  `https://unpkg.com/pdfjs-dist@${version}/build/pdf.worker.min.mjs`;
```

`build/pdf.worker.min.mjs` is still shipped in v6, so that URL remains valid — worth confirming, since a missing worker fails at runtime with no compile-time signal.

## Runtime exports

All six imported symbols are present in v6 — `AnnotationLayer`, `TextLayer`, `setLayerDimensions`, `GlobalWorkerOptions`, `getDocument`, `version`. Checked against the `legacy` build, since the default build needs DOM globals and throws `ReferenceError: DOMMatrix is not defined` under plain Node.

## Lockfile

13 version changes. Twelve are `@napi-rs/canvas` platform binaries going 0.1.100 → 1.0.3 — a transitive of pdfjs-dist marked `optional: true` (its Node-side canvas renderer), so browser builds are unaffected. 0 added, 0 removed.

## Verification

| Check | Result |
| --- | --- |
| `tsc --noEmit` — `libs/ui-lab`, `apps/showcase` | exit 0 |
| v4/v5/v6 API compatibility of the replacements | confirmed against published types |
| Worker file present in v6 | yes |
| Runtime exports (6) | all present |
| `nx run-many -t lint` | 11 projects, 0 errors |
| `prettier --check` | clean |
| `validate-demo-code.mjs` | 0 mismatches |

CI's e2e covers the pdf-viewer demo page, which is the real check that rendering still works in a browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
