### PR TITLE
refactor: use the linkedSignal set interceptor instead of write-back effects

### DIFF
--- a/apps/showcase/src/app/pages/docs/query-param-state/demos/demo-query-param-state-demo-container.ts
+++ b/apps/showcase/src/app/pages/docs/query-param-state/demos/demo-query-param-state-demo-container.ts
@@ -19,13 +19,7 @@ import { DemoQueryParamStateDemo } from './demo-query-param-state-demo';
   encapsulation: ViewEncapsulation.None,
 })
 export class DemoQueryParamStateDemoContainer {
-  readonly code = `import {
-  Component,
-  ViewEncapsulation,
-  effect,
-  linkedSignal,
-  untracked,
-} from '@angular/core';
+  readonly code = `import { Component, ViewEncapsulation, linkedSignal } from '@angular/core';
 import { FormField, form, min } from '@angular/forms/signals';
 import {
   injectQueryParam,
@@ -104,28 +98,30 @@ export class DemoQueryParamStateDemo {
     parseAsStringEnum(['asc', 'desc'] as const).withDefault('asc'),
   );
 
-  /** Resets whenever the URL changes, so the form always mirrors the query params. */
-  readonly formModel = linkedSignal(() => ({
-    q: this.search.value(),
-    page: this.page.value(),
-    sort: this.sort.value(),
-  }));
+  /**
+   * Resets whenever the URL changes, so the form always mirrors the query
+   * params. The \`set\` interceptor pushes form edits straight back into the
+   * params — synchronously, and without an effect.
+   */
+  readonly formModel = linkedSignal(
+    () => ({
+      q: this.search.value(),
+      page: this.page.value(),
+      sort: this.sort.value(),
+    }),
+    {
+      set: ({ q, page, sort }, rawSet) => {
+        rawSet({ q, page, sort });
+        if (q !== this.search.value()) this.search.set(q);
+        if (page !== this.page.value()) this.page.set(page);
+        if (sort !== this.sort.value()) this.sort.set(sort);
+      },
+    },
+  );
 
   readonly filtersForm = form(this.formModel, (path) => {
     min(path.page, 1, { message: 'Page must be at least 1' });
   });
-
-  constructor() {
-    // Push edits made through the form back into the URL.
-    effect(() => {
-      const { q, page, sort } = this.formModel();
-      untracked(() => {
-        if (q !== this.search.value()) this.search.set(q);
-        if (page !== this.page.value()) this.page.set(page);
-        if (sort !== this.sort.value()) this.sort.set(sort);
-      });
-    });
-  }
 
   stateJson() {
     return JSON.stringify(

--- a/apps/showcase/src/app/pages/docs/query-param-state/demos/demo-query-param-state-demo.ts
+++ b/apps/showcase/src/app/pages/docs/query-param-state/demos/demo-query-param-state-demo.ts
@@ -1,10 +1,4 @@
-import {
-  Component,
-  ViewEncapsulation,
-  effect,
-  linkedSignal,
-  untracked,
-} from '@angular/core';
+import { Component, ViewEncapsulation, linkedSignal } from '@angular/core';
 import { FormField, form, min } from '@angular/forms/signals';
 import {
   injectQueryParam,
@@ -83,28 +77,30 @@ export class DemoQueryParamStateDemo {
     parseAsStringEnum(['asc', 'desc'] as const).withDefault('asc'),
   );
 
-  /** Resets whenever the URL changes, so the form always mirrors the query params. */
-  readonly formModel = linkedSignal(() => ({
-    q: this.search.value(),
-    page: this.page.value(),
-    sort: this.sort.value(),
-  }));
+  /**
+   * Resets whenever the URL changes, so the form always mirrors the query
+   * params. The `set` interceptor pushes form edits straight back into the
+   * params — synchronously, and without an effect.
+   */
+  readonly formModel = linkedSignal(
+    () => ({
+      q: this.search.value(),
+      page: this.page.value(),
+      sort: this.sort.value(),
+    }),
+    {
+      set: ({ q, page, sort }, rawSet) => {
+        rawSet({ q, page, sort });
+        if (q !== this.search.value()) this.search.set(q);
+        if (page !== this.page.value()) this.page.set(page);
+        if (sort !== this.sort.value()) this.sort.set(sort);
+      },
+    },
+  );
 
   readonly filtersForm = form(this.formModel, (path) => {
     min(path.page, 1, { message: 'Page must be at least 1' });
   });
-
-  constructor() {
-    // Push edits made through the form back into the URL.
-    effect(() => {
-      const { q, page, sort } = this.formModel();
-      untracked(() => {
-        if (q !== this.search.value()) this.search.set(q);
-        if (page !== this.page.value()) this.page.set(page);
-        if (sort !== this.sort.value()) this.sort.set(sort);
-      });
-    });
-  }
 
   stateJson() {
     return JSON.stringify(

--- a/apps/showcase/src/app/query-param-state-demo.spec.ts
+++ b/apps/showcase/src/app/query-param-state-demo.spec.ts
@@ -1,0 +1,50 @@
+import { TestBed } from '@angular/core/testing';
+import { Router, provideRouter } from '@angular/router';
+import { DemoQueryParamStateDemo } from './pages/docs/query-param-state/demos/demo-query-param-state-demo';
+
+async function mountDemo(url = '/'): Promise<DemoQueryParamStateDemo> {
+  TestBed.configureTestingModule({
+    providers: [provideRouter([{ path: '**', children: [] }])],
+  });
+  await TestBed.inject(Router).navigateByUrl(url);
+  const fixture = TestBed.createComponent(DemoQueryParamStateDemo);
+  fixture.detectChanges();
+  return fixture.componentInstance;
+}
+
+describe('DemoQueryParamStateDemo', () => {
+  it('mirrors the URL into the form model', async () => {
+    const c = await mountDemo('/?q=angular&page=3&sort=desc');
+
+    expect(c.formModel()).toEqual({ q: 'angular', page: 3, sort: 'desc' });
+  });
+
+  it('pushes a form-model edit back into the params synchronously', async () => {
+    const c = await mountDemo('/?q=angular&page=3&sort=desc');
+
+    // This is the write path signal forms uses when a field changes.
+    c.formModel.update((m) => ({ ...m, q: 'signals' }));
+
+    expect(c.search.value()).toBe('signals');
+    expect(c.page.value()).toBe(3);
+    expect(c.sort.value()).toBe('desc');
+  });
+
+  it('keeps the form model consistent after the edit', async () => {
+    const c = await mountDemo('/?q=angular&page=3&sort=desc');
+
+    c.formModel.update((m) => ({ ...m, page: 7 }));
+
+    expect(c.formModel()).toEqual({ q: 'angular', page: 7, sort: 'desc' });
+  });
+
+  it('reset() clears every param', async () => {
+    const c = await mountDemo('/?q=angular&page=3&sort=desc');
+
+    c.reset();
+
+    expect(c.search.value()).toBe('');
+    expect(c.page.value()).toBe(1);
+    expect(c.sort.value()).toBe('asc');
+  });
+});

--- a/apps/showcase/src/app/query-param-state.spec.ts
+++ b/apps/showcase/src/app/query-param-state.spec.ts
@@ -27,6 +27,13 @@ async function mount<T>(type: new () => T, url = '/'): Promise<T> {
   return TestBed.createComponent(type).componentInstance;
 }
 
+/** Run effects, then let the service's microtask batch and the router settle. */
+async function settle(): Promise<void> {
+  TestBed.tick();
+  for (let i = 0; i < 5; i++) await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
 describe('injectQueryParam', () => {
   it('seeds both call sites for a key from the URL', async () => {
     const c = await mount(TwoCallSites, '/?q=hello');
@@ -34,23 +41,30 @@ describe('injectQueryParam', () => {
     expect(c.b.value()).toBe('hello');
   });
 
-  it('propagates a write to a sibling call site in the same tick', async () => {
+  it('propagates a write to a sibling call site synchronously', async () => {
     const c = await mount(TwoCallSites, '/?q=hello');
 
     c.a.set('world');
-    TestBed.tick();
 
-    // Before the fix this stayed 'hello' until the router round-trip landed.
+    // No tick: the linkedSignal `set` interceptor publishes to the shared raw
+    // value during the write itself, not on the next change detection.
     expect(c.b.value()).toBe('world');
   });
 
-  it('propagates clear() to a sibling call site', async () => {
+  it('propagates clear() to a sibling call site synchronously', async () => {
     const c = await mount(TwoCallSites, '/?q=hello');
 
     c.a.clear();
-    TestBed.tick();
 
     expect(c.b.value()).toBe('');
+  });
+
+  it('propagates a write made through the exposed signal', async () => {
+    const c = await mount(TwoCallSites, '/?q=hello');
+
+    c.a.value.set('direct');
+
+    expect(c.b.value()).toBe('direct');
   });
 
   it('reflects external navigation into every call site', async () => {
@@ -63,11 +77,36 @@ describe('injectQueryParam', () => {
     expect(c.b.value()).toBe('external');
   });
 
+  it('projects the value onto the URL', async () => {
+    const c = await mount(TwoCallSites, '/?q=hello');
+
+    c.a.set('world');
+    await settle();
+
+    expect(c.router.url).toContain('q=world');
+  });
+
+  it('strips the param from the URL on clear()', async () => {
+    const c = await mount(TwoCallSites, '/?q=hello');
+
+    c.a.clear();
+    await settle();
+
+    expect(c.router.url).not.toContain('q=');
+  });
+
   it('corrects a value the parser cannot round-trip', async () => {
     const c = await mount(Truncating, '/?page=2');
 
     c.page.set(3.7);
-    TestBed.tick();
+
+    expect(c.page.value()).toBe(3);
+  });
+
+  it('corrects even when the serialised form already matches the URL', async () => {
+    const c = await mount(Truncating, '/?page=3');
+
+    c.page.set(3.7);
 
     expect(c.page.value()).toBe(3);
   });

--- a/apps/showcase/src/app/resizable-panel.spec.ts
+++ b/apps/showcase/src/app/resizable-panel.spec.ts
@@ -1,0 +1,67 @@
+import { Component, viewChild } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import {
+  ScResizablePanel,
+  ScResizablePanelGroup,
+} from '@semantic-components/ui';
+
+@Component({
+  imports: [ScResizablePanel, ScResizablePanelGroup],
+  template: `
+    <div scResizablePanelGroup direction="horizontal">
+      <div scResizablePanel [minSize]="20" [maxSize]="80" [defaultSize]="50">
+        a
+      </div>
+    </div>
+  `,
+})
+class PanelHost {
+  readonly panel = viewChild.required(ScResizablePanel);
+}
+
+function mountPanel(): PanelHost {
+  TestBed.configureTestingModule({});
+  const fixture = TestBed.createComponent(PanelHost);
+  fixture.detectChanges();
+  return fixture.componentInstance;
+}
+
+describe('ScResizablePanel', () => {
+  it('takes its initial size from defaultSize', () => {
+    expect(mountPanel().panel().size()).toBe(50);
+  });
+
+  it('clamps a direct size.set() above maxSize', () => {
+    const panel = mountPanel().panel();
+
+    // Before the set interceptor this bypassed the clamp entirely, because
+    // only setSize() applied it.
+    panel.size.set(999);
+
+    expect(panel.size()).toBe(80);
+  });
+
+  it('clamps a direct size.set() below minSize', () => {
+    const panel = mountPanel().panel();
+
+    panel.size.set(-5);
+
+    expect(panel.size()).toBe(20);
+  });
+
+  it('still clamps through setSize()', () => {
+    const panel = mountPanel().panel();
+
+    panel.setSize(999);
+
+    expect(panel.size()).toBe(80);
+  });
+
+  it('leaves an in-range value untouched', () => {
+    const panel = mountPanel().panel();
+
+    panel.size.set(35);
+
+    expect(panel.size()).toBe(35);
+  });
+});

--- a/libs/ui-lab/src/lib/utilities/query-param-state/inject-query-param.ts
+++ b/libs/ui-lab/src/lib/utilities/query-param-state/inject-query-param.ts
@@ -70,26 +70,31 @@ export function injectQueryParam<T>(
     sync.write(key, null, parser._options);
   }
 
-  // Typed view of the shared raw value, locally writable so `set` can update
-  // optimistically before the URL catches up. External changes (back/forward,
-  // hand-edited links, a sibling call site) reset it through `source`.
+  const parseRaw = (value: string | null): T | null =>
+    value === null ? defaultValue : (parser.parse(value) ?? defaultValue);
+
+  const serializeValue = (value: T | null): string | null =>
+    value === null || isDefault(value) ? null : parser.serialize(value);
+
+  // Typed view of the shared raw value. External changes (back/forward,
+  // hand-edited links, another call site) reset it through `source`; local
+  // writes are intercepted by `set` and published to the shared raw value
+  // synchronously, so sibling call sites for the same key observe them in the
+  // same statement rather than on the next change detection. The URL write
+  // stays debounced downstream, independently of this.
   const sig = linkedSignal<string | null, T | null>({
     source: raw,
-    computation: (value) =>
-      value === null ? defaultValue : (parser.parse(value) ?? defaultValue),
-  });
-
-  // Local writes publish to the shared raw value immediately, so sibling call
-  // sites for the same key converge in this tick rather than waiting on the URL
-  // round-trip — which `debounceMs` can defer for as long as the user keeps
-  // typing. No "skip the first run" guard here: `raw` is seeded from the URL,
-  // so the initial pass is already a no-op by equality, and skipping a run by
-  // counter would swallow a write made before the first change detection.
-  effect(() => {
-    const value = sig();
-    const next =
-      value === null || isDefault(value) ? null : parser.serialize(value);
-    if (next !== untracked(raw)) raw.set(next);
+    computation: (value) => parseRaw(value),
+    set: (value, rawSet) => {
+      const next = serializeValue(value);
+      if (next !== untracked(raw)) {
+        // Changing the source re-runs `computation`, which canonicalises the
+        // value: page.set(3.7) with parseAsInteger settles on 3.
+        raw.set(next);
+      } else {
+        rawSet(parseRaw(next));
+      }
+    },
   });
 
   // The URL is a projection of the shared raw value, optionally debounced. The

--- a/libs/ui/src/lib/components/resizable/resizable-panel.ts
+++ b/libs/ui/src/lib/components/resizable/resizable-panel.ts
@@ -33,7 +33,16 @@ export class ScResizablePanel {
   readonly minSize = input<number>(0);
   readonly maxSize = input<number>(100);
 
-  readonly size = linkedSignal(() => this.defaultSize());
+  /**
+   * Clamping lives in the `set` interceptor rather than in `setSize`, so a
+   * direct `size.set(...)` from a consumer honours minSize/maxSize too.
+   */
+  readonly size = linkedSignal<number, number>({
+    source: () => this.defaultSize(),
+    computation: (defaultSize) => defaultSize,
+    set: (value, rawSet) =>
+      rawSet(Math.max(this.minSize(), Math.min(this.maxSize(), value))),
+  });
 
   protected readonly class = computed(() =>
     cn('overflow-hidden', this.classInput()),
@@ -43,7 +52,6 @@ export class ScResizablePanel {
   protected readonly maxSizePx = computed(() => `${this.maxSize()}%`);
 
   setSize(newSize: number): void {
-    const clamped = Math.max(this.minSize(), Math.min(this.maxSize(), newSize));
-    this.size.set(clamped);
+    this.size.set(newSize);
   }
 }


### PR DESCRIPTION
`linkedSignal` accepts a `set` option that intercepts writes:

```ts
set?: (value: NoInfer<D>, rawSet: (value: NoInfer<D>) => void) => void;
```

It replaces the effect-based write-back pattern across the workspace. Unlike an effect, it runs **during the write** rather than on the next change detection.

### `injectQueryParam`

The publish effect becomes a `set` interceptor, so sibling call sites for a key converge synchronously. The two sibling tests no longer need `TestBed.tick()` — that's the direct evidence.

This also removes the *class* of bug fixed in #1479: an effect-based publish path structurally cannot see a write made before a component's first change detection, which is why the "skip the first run" counters were swallowing writes.

### `ScResizablePanel`

min/max clamping moves out of `setSize()` and into the interceptor:

```ts
readonly size = linkedSignal<number, number>({
  source: () => this.defaultSize(),
  computation: (defaultSize) => defaultSize,
  set: (value, rawSet) =>
    rawSet(Math.max(this.minSize(), Math.min(this.maxSize(), value))),
});
```

`size` is public and writable, so `panel.size.set(999)` previously bypassed the clamp entirely — only `setSize()` applied it. Now the invariant holds on every write path.

### query-param-state demo

Drops its constructor `effect` + `untracked` block for the same interceptor.

### Verification

- **18/18 unit tests pass**; lint 0 errors across all 11 projects (warning counts unchanged); `ui` and `ui-lab` typecheck clean.
- Confirmed `update()` routes through the interceptor *before* relying on it — that's how signal forms writes into a form model.
- New specs for the resizable clamp and the demo write-back were checked against the previous implementations: the synchronous demo test and the two direct-`set` clamp tests fail there, so they're testing the change rather than tautologies.
- Demo container code regenerated via `sync-demo-code.mjs`; `validate-demo-code.mjs` reports 0 mismatches.

### Deliberately left alone

`ScPagination`'s `currentPage` / `pageSize` and `ScCalendar`'s `viewMode` are plain input mirrors with no invariant to enforce. Clamping pagination would change public behaviour of a shipped component (`totalPages` is 0 when `totalItems` is 0, so a naive clamp lands on 0 rather than 1) — worth deciding separately rather than folding in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
