### PR TITLE
fix(button): restore hover on the default variant, align with shadcn nova

### DIFF
--- a/libs/ui/src/lib/components/badge/badge.ts
+++ b/libs/ui/src/lib/components/badge/badge.ts
@@ -28,7 +28,9 @@ export const badgeVariants = cva(
 export type ScBadgeVariants = VariantProps<typeof badgeVariants>;
 
 @Directive({
-  selector: 'div[scBadge], span[scBadge]',
+  // `a` is included so the `[a]:hover:*` variants above can match: a badge is
+  // only interactive when it is a link.
+  selector: 'div[scBadge], span[scBadge], a[scBadge]',
   host: {
     '[class]': 'class()',
   },

--- a/libs/ui/src/lib/components/button/button.ts
+++ b/libs/ui/src/lib/components/button/button.ts
@@ -3,15 +3,15 @@ import { type VariantProps, cva } from 'class-variance-authority';
 import { cn } from '../../utils';
 
 export const buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {
-        default: 'bg-primary text-primary-foreground [a]:hover:bg-primary/80',
+        default: 'bg-primary text-primary-foreground hover:bg-primary/80',
         outline:
           'border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50',
         secondary:
-          'bg-secondary text-secondary-foreground hover:bg-secondary/80 aria-expanded:bg-secondary aria-expanded:text-secondary-foreground',
+          'bg-secondary text-secondary-foreground hover:bg-[color-mix(in_oklch,var(--secondary),var(--foreground)_5%)] aria-expanded:bg-secondary aria-expanded:text-secondary-foreground',
         ghost:
           'hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50',
         destructive:
@@ -23,7 +23,7 @@ export const buttonVariants = cva(
           'h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pe-2 has-data-[icon=inline-start]:ps-2',
         xs: "h-6 gap-1 rounded-[min(var(--radius-md),10px)] px-2 text-xs in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pe-1.5 has-data-[icon=inline-start]:ps-1.5 [&_svg:not([class*='size-'])]:size-3",
         sm: "h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pe-1.5 has-data-[icon=inline-start]:ps-1.5 [&_svg:not([class*='size-'])]:size-3.5",
-        lg: 'h-9 gap-1.5 px-2.5 has-data-[icon=inline-end]:pe-3 has-data-[icon=inline-start]:ps-3',
+        lg: 'h-9 gap-1.5 px-2.5 has-data-[icon=inline-end]:pe-2 has-data-[icon=inline-start]:ps-2',
         icon: 'size-8',
         'icon-xs':
           "size-6 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-lg [&_svg:not([class*='size-'])]:size-3",

--- a/libs/ui/src/lib/components/item/item.ts
+++ b/libs/ui/src/lib/components/item/item.ts
@@ -27,7 +27,9 @@ export const itemVariants = cva(
 export type ScItemVariants = VariantProps<typeof itemVariants>;
 
 @Directive({
-  selector: 'div[scItem]',
+  // `a` is included so the `[a]:hover:*` variants above can match: an item is
+  // only interactive when it is a link.
+  selector: 'div[scItem], a[scItem]',
   host: {
     '[attr.data-variant]': 'variant()',
     '[attr.data-size]': 'size()',


### PR DESCRIPTION
## The bug

`buttonVariants`' default variant gated its hover on the host element:

```ts
default: 'bg-primary text-primary-foreground [a]:hover:bg-primary/80',
```

Tailwind compiles `[a]:` to `:is(a)` — verified by compiling it through the repo's own Tailwind 4.3.3:

```css
.\[a\]\:hover\:bg-red-500:is(a):hover { … }
```

`buttonVariants` has 52 consumers, six of which can render as an anchor (`ScLink` is `a[scLink]`; five pagination directives accept `a` or `button`). So the same `variant="default"` behaved **two different ways depending on the host element**:

| Host | Hover before |
|---|---|
| `<a scLink>`, `<a scPaginationLink>` | works |
| `<button scButton>`, `<button scPaginationLink>` | **none** |

`ScButton`'s selector is `button[scButton]`, so the flagship case — a plain default button — had no hover state at all. The string is byte-identical to `badge.ts:10`, so it was a copy-paste, and `default` is the only variant of ours carrying the guard; `outline`, `secondary`, `ghost`, `destructive` and `link` all use a plain `hover:`.

Upstream applies it unconditionally:

```css
.cn-button-variant-default { @apply bg-primary text-primary-foreground hover:bg-primary/80; }
```

Dropping the guard regresses nothing: `hover:` matches anchors and buttons alike, so the six anchor consumers keep their hover and every button consumer gains it.

## Also aligned with `style-nova.css`

| | before | after |
|---|---|---|
| `secondary` hover | `bg-secondary/80` | `bg-[color-mix(in_oklch,var(--secondary),var(--foreground)_5%)]` |
| `lg` icon padding | `pe-3` / `ps-3` | `pe-2` / `ps-2` |
| press animation | `active:translate-y-px` | `active:not-aria-[haspopup]:translate-y-px` |

`secondary` is a behavioural difference, not just a value: `/80` goes translucent and lets the backdrop bleed through on hover, where upstream stays opaque and darkens by mixing in 5% foreground. The press-animation guard stops dropdown and popover triggers from nudging down on press.

These apply to all 52 consumers, not just `ScButton`.

## Why button dropped the guard but badge and item kept it

Different problems, despite the identical-looking symptom.

**Badge and item** use `[a]:hover:` exactly as upstream does, and there it is deliberate: a badge or item is only interactive when it is a link. Those rules were unreachable purely because the Angular selectors accepted `div`/`span` alone, and neither has an `ScLink`-style counterpart. So the fix is to widen the selectors — stripping the guard would give static badges a hover effect shadcn deliberately avoids. Additive; no existing usage changes.

**Button** is the opposite: upstream has no guard there, and the anchor-as-button case is already served by `ScLink` reusing `buttonVariants`. Adding `a[scButton]` would duplicate `ScLink` and make two directives compete for the same element.

## Deliberately kept

Logical properties (`pe-*`/`ps-*`) for RTL, and `aria-disabled:pointer-events-none aria-disabled:opacity-50`, which upstream lacks but is correct here since the host binds `[attr.aria-disabled]`.

## Verification

Each changed class was compiled through the project's Tailwind to confirm its output selector, rather than reasoning about the syntax:

- `hover:bg-primary/80` → `:hover` ✓
- `active:not-aria-[haspopup]:translate-y-px` → `:active:not([aria-haspopup])` ✓
- `has-data-[icon=inline-end]:pe-2` → `padding-inline-end` ✓
- the `color-mix` arbitrary value emits valid CSS ✓

`--secondary` and `--foreground` are confirmed defined in both the light and dark blocks of `shadcn.css`, so the mix resolves in both themes. `nx lint ui` clean, `tsc --noEmit` exit 0, 18/18 tests pass.

Styling-only change with no test coverage for computed classes — worth an eyeball on the button, link, badge and pagination demo pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)