### PR TITLE
fix(rtl): use logical properties for direction-sensitive utilities

### DIFF
--- a/docs/shadcn-style-reference.md
+++ b/docs/shadcn-style-reference.md
@@ -39,13 +39,14 @@ So when comparing our styling to shadcn's, **read the CSS file**. Reading the
 
 All paths are under `https://github.com/shadcn-ui/ui/tree/main/`.
 
-| What you want                                      | Path                                            |
-| -------------------------------------------------- | ----------------------------------------------- |
-| **Styles** (class declarations)                    | `apps/v4/registry/styles/style-<theme>.css`     |
-| Component source (structure, slots, variant names) | `apps/v4/registry/bases/base/ui/*.tsx`          |
-| Usage examples / demos                             | `apps/v4/examples/base/*.tsx`                   |
-| Theme list and metadata                            | `apps/v4/registry/styles.tsx`                   |
-| Defaults                                           | `apps/v4/registry/config.ts` (`DEFAULT_CONFIG`) |
+| What you want                                      | Path                                                      |
+| -------------------------------------------------- | --------------------------------------------------------- |
+| **Styles** (class declarations)                    | `apps/v4/registry/styles/style-<theme>.css`               |
+| Component source (structure, slots, variant names) | `apps/v4/registry/bases/base/ui/*.tsx`                    |
+| Usage examples / demos                             | `apps/v4/examples/base/*.tsx`                             |
+| Theme list and metadata                            | `apps/v4/registry/styles.tsx`                             |
+| Defaults                                           | `apps/v4/registry/config.ts` (`DEFAULT_CONFIG`)           |
+| **RTL mapping table**                              | `packages/shadcn/src/utils/transformers/transform-rtl.ts` |
 
 > Historical note: the path `apps/v4/examples/base/ui` no longer exists. If you
 > find it referenced anywhere, it is stale.
@@ -98,6 +99,59 @@ The full set (8 themes, ~70KB each):
 
 They differ in real spacing and radius values, so make sure you are diffing
 against `nova` and not whichever file you opened first.
+
+## The styles you are reading are LTR-first
+
+This is the second thing that trips people up. `style-nova.css` is full of
+**physical** properties — 49 uses of `pr-*`/`pl-*`/`mr-*`/`ml-*`, against 2
+logical ones, and not a single `[dir=rtl]` or `:dir()` anywhere.
+
+That does **not** mean shadcn ignores RTL. RTL is a **build-time transform**, not
+something expressed in the CSS. The registry build generates a parallel
+`styles/<style>/ui-rtl/` tree by running every component through
+`transformDirection()`, which rewrites physical classes to logical ones. The RTL
+demos import from that tree:
+
+```tsx
+// examples/base/badge-rtl.tsx
+import { Badge } from '@/styles/base-nova/ui-rtl/badge';
+```
+
+**That tree is gitignored** — `apps/v4/styles/` contains only a README on GitHub.
+You cannot fetch the RTL output; you have to apply the mapping yourself (or
+generate it with `pnpm --filter=v4 registry:build --style all` in a clone).
+
+The same transform ships to consumers as `shadcn migrate rtl`.
+
+### Consequence for comparing
+
+**Apply the mapping before you diff, or every logical class in our code will look
+like a divergence when it is actually the correct transformed form.** Our
+`pe-2`/`ps-2` is exactly what `transformDirection` produces from upstream's
+`pr-2`/`pl-2` — same style, further along the pipeline.
+
+The table in `transform-rtl.ts` is the authority. Direct replacements:
+
+```
+-ml- → -ms-      pl-  → ps-      left-  → start-    rounded-l- → rounded-s-
+-mr- → -me-      pr-  → pe-      right- → end-      rounded-tl- → rounded-ss-
+ml-  → ms-       text-left  → text-start     border-l- → border-s-
+mr-  → me-       text-right → text-end       border-r- → border-e-
+scroll-pl- → scroll-ps-    float-left  → float-start    origin-left → origin-start
+```
+
+Four rules are not simple renames, and are the easiest to miss:
+
+| Case              | Rule                                                  |
+| ----------------- | ----------------------------------------------------- |
+| `translate-x-*`   | add an `rtl:` variant with the sign flipped           |
+| `space-x-*`       | add `rtl:space-x-reverse` (likewise `divide-x-*`)     |
+| `cn-rtl-flip`     | marker class → becomes `rtl:rotate-180`               |
+| `cursor-w-resize` | add `rtl:` variant with the value swapped (`w` ↔ `e`) |
+
+`cn-rtl-flip` is worth calling out: it is how upstream flips **directional
+icons** — chevrons and arrows in pagination, carousel and breadcrumb. Grep
+upstream for it to find every icon that must rotate in RTL.
 
 ## Fetching a file
 
@@ -159,13 +213,17 @@ stylesheet, so the comparison is per-class rather than file-to-file. For a given
 component: pull the `cn-*` block out of `nova.css`, then read the matching
 `libs/ui/src/lib/components/<name>/*.ts`.
 
+**Logical properties are not a divergence.** We write `pe-*`, `ms-*`,
+`border-e`, `text-start` inline, which is the _output_ of upstream's RTL
+transform. Run the mapping in the section above over the shadcn class before
+concluding anything differs. Where our code still uses a physical property, that
+is a bug, not a style choice — the repo is RTL-first by policy.
+
 Known deliberate divergences — do **not** "fix" these to match upstream:
 
 - **`--destructive`** is darkened to `oklch(0.52 0.245 27.325)` (shadcn ships
   `0.577`) so that the `bg-destructive/10 text-destructive` pairing clears the
   4.5:1 WCAG AA contrast minimum.
-- **RTL** — we use logical properties (`border-e`, `ms-*`, `pe-*`, `text-start`)
-  where upstream uses physical ones in places.
 - **Decomposition** — upstream ships one file per component; we split into
   composable directives, so one shadcn class often maps to several of our
   directives.

--- a/libs/code/src/lib/components/code-editor/code-editor-content.ts
+++ b/libs/code/src/lib/components/code-editor/code-editor-content.ts
@@ -126,7 +126,7 @@ export function detectLanguage(
     <!-- Line numbers -->
     @if (showLineNumbers()) {
       <div
-        class="sc-code-editor-content__line-numbers border-border shrink-0 border-r py-3 pr-3 pl-3 text-right select-none"
+        class="sc-code-editor-content__line-numbers border-border shrink-0 border-e py-3 ps-3 pe-3 text-end select-none"
         [style.min-width.ch]="lineNumberWidth()"
         aria-hidden="true"
       >

--- a/libs/ui-lab/src/lib/components/audio-player/audio-player-progress.ts
+++ b/libs/ui-lab/src/lib/components/audio-player/audio-player-progress.ts
@@ -12,7 +12,7 @@ import { SC_AUDIO_PLAYER } from './audio-player';
   selector: 'div[scAudioPlayerProgress]',
   imports: [ScSlider],
   template: `
-    <span class="text-muted-foreground w-10 text-right text-xs">
+    <span class="text-muted-foreground w-10 text-end text-xs">
       {{ player.formatTime(player.currentTime()) }}
     </span>
     <div class="group relative h-3 flex-1">

--- a/libs/ui-lab/src/lib/components/data-table/data-table-cell.ts
+++ b/libs/ui-lab/src/lib/components/data-table/data-table-cell.ts
@@ -12,7 +12,7 @@ export class ScDataTableCell {
 
   protected readonly class = computed(() =>
     cn(
-      'p-2 align-middle [&:has([role=checkbox])]:pr-0 *:[[role=checkbox]]:translate-y-[2px]',
+      'p-2 align-middle [&:has([role=checkbox])]:pe-0 *:[[role=checkbox]]:translate-y-[2px]',
       this.classInput(),
     ),
   );

--- a/libs/ui-lab/src/lib/components/data-table/data-table-head.ts
+++ b/libs/ui-lab/src/lib/components/data-table/data-table-head.ts
@@ -20,7 +20,7 @@ import { SC_DATA_TABLE, SortDirection } from './data-table';
     @if (sortable()) {
       <button
         type="button"
-        class="hover:text-foreground hover:bg-accent -ml-3 flex h-8 items-center gap-1 rounded-md px-3"
+        class="hover:text-foreground hover:bg-accent -ms-3 flex h-8 items-center gap-1 rounded-md px-3"
         (click)="onSort()"
       >
         <ng-content />
@@ -53,7 +53,7 @@ export class ScDataTableHead {
 
   protected readonly class = computed(() =>
     cn(
-      'h-10 px-2 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0 *:[[role=checkbox]]:translate-y-[2px]',
+      'h-10 px-2 text-start align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pe-0 *:[[role=checkbox]]:translate-y-[2px]',
       'group',
       this.classInput(),
     ),

--- a/libs/ui-lab/src/lib/components/data-table/data-table-pagination.ts
+++ b/libs/ui-lab/src/lib/components/data-table/data-table-pagination.ts
@@ -33,8 +33,8 @@ import { SC_DATA_TABLE } from './data-table';
           {{ table.sortedData().length }} row(s) total.
         }
       </div>
-      <div class="flex items-center space-x-6 lg:space-x-8">
-        <div class="flex items-center space-x-2">
+      <div class="flex items-center space-x-6 lg:space-x-8 rtl:space-x-reverse">
+        <div class="flex items-center space-x-2 rtl:space-x-reverse">
           <p class="text-sm font-medium">Rows per page</p>
           <select
             class="border-input bg-background h-8 w-[70px] rounded-md border text-sm"
@@ -51,7 +51,7 @@ import { SC_DATA_TABLE } from './data-table';
         >
           Page {{ currentPage() }} of {{ totalPages() }}
         </div>
-        <div class="flex items-center space-x-2">
+        <div class="flex items-center space-x-2 rtl:space-x-reverse">
           <button
             type="button"
             class="border-input bg-background hover:bg-accent inline-flex size-8 items-center justify-center rounded-md border disabled:opacity-50"

--- a/libs/ui-lab/src/lib/components/date-range-picker/date-range-picker-footer.ts
+++ b/libs/ui-lab/src/lib/components/date-range-picker/date-range-picker-footer.ts
@@ -11,7 +11,7 @@ import { ScDateRangePicker } from './date-range-picker';
 @Component({
   selector: 'div[scDateRangePickerFooter]',
   template: `
-    <div class="ml-auto flex gap-2">
+    <div class="ms-auto flex gap-2">
       <button
         type="button"
         class="border-input hover:bg-accent inline-flex h-8 items-center justify-center rounded-md border px-3 text-sm font-medium"

--- a/libs/ui-lab/src/lib/components/date-range-picker/date-range-picker-preset.ts
+++ b/libs/ui-lab/src/lib/components/date-range-picker/date-range-picker-preset.ts
@@ -26,7 +26,7 @@ export class ScDateRangePickerPreset {
 
   protected readonly class = computed(() =>
     cn(
-      'text-left px-3 py-2 text-sm rounded-md',
+      'text-start px-3 py-2 text-sm rounded-md',
       'hover:bg-accent hover:text-accent-foreground',
       this.isActive() && 'bg-accent text-accent-foreground',
       this.classInput(),

--- a/libs/ui-lab/src/lib/components/date-range-picker/date-range-picker-presets.ts
+++ b/libs/ui-lab/src/lib/components/date-range-picker/date-range-picker-presets.ts
@@ -15,6 +15,6 @@ export class ScDateRangePickerPresets {
   readonly classInput = input<string>('', { alias: 'class' });
 
   protected readonly class = computed(() =>
-    cn('flex min-w-[140px] flex-col gap-1 border-r p-3', this.classInput()),
+    cn('flex min-w-[140px] flex-col gap-1 border-e p-3', this.classInput()),
   );
 }

--- a/libs/ui-lab/src/lib/components/diff-viewer/diff-viewer-line-number.ts
+++ b/libs/ui-lab/src/lib/components/diff-viewer/diff-viewer-line-number.ts
@@ -12,7 +12,7 @@ export class ScDiffViewerLineNumber {
 
   protected readonly class = computed(() =>
     cn(
-      'text-muted-foreground inline-block w-12 border-r px-2 text-right select-none',
+      'text-muted-foreground inline-block w-12 border-e px-2 text-end select-none',
       this.classInput(),
     ),
   );

--- a/libs/ui-lab/src/lib/components/diff-viewer/diff-viewer-pane.ts
+++ b/libs/ui-lab/src/lib/components/diff-viewer/diff-viewer-pane.ts
@@ -14,7 +14,7 @@ export class ScDiffViewerPane {
   protected readonly class = computed(() =>
     cn(
       'min-w-0 flex-1',
-      this.side() === 'old' && 'border-r',
+      this.side() === 'old' && 'border-e',
       this.classInput(),
     ),
   );

--- a/libs/ui-lab/src/lib/components/lightbox/lightbox-zoom-controls.ts
+++ b/libs/ui-lab/src/lib/components/lightbox/lightbox-zoom-controls.ts
@@ -13,6 +13,6 @@ export class ScLightboxZoomControls {
   readonly classInput = input<string>('', { alias: 'class' });
 
   protected readonly class = computed(() =>
-    cn('ml-4 flex items-center gap-1', this.classInput()),
+    cn('ms-4 flex items-center gap-1', this.classInput()),
   );
 }

--- a/libs/ui-lab/src/lib/components/mention-input/mention-input-suggestion-item.ts
+++ b/libs/ui-lab/src/lib/components/mention-input/mention-input-suggestion-item.ts
@@ -25,7 +25,7 @@ import type { MentionUser } from './mention-input-types';
         {{ user().name.charAt(0).toUpperCase() }}
       </div>
     }
-    <div class="flex-1 text-left">
+    <div class="flex-1 text-start">
       <div class="text-sm font-medium">{{ user().name }}</div>
       <div class="text-muted-foreground text-xs">
         &#64;{{ user().username }}

--- a/libs/ui-lab/src/lib/components/notification-center/notification-item.ts
+++ b/libs/ui-lab/src/lib/components/notification-center/notification-item.ts
@@ -36,7 +36,7 @@ import type { Notification, NotificationAction } from './notification-types';
     }
 
     <!-- Icon or Avatar -->
-    <div class="ml-4 shrink-0">
+    <div class="ms-4 shrink-0">
       @if (notification().avatar) {
         <img
           [src]="notification().avatar"
@@ -71,7 +71,7 @@ import type { Notification, NotificationAction } from './notification-types';
     </div>
 
     <!-- Content -->
-    <div class="ml-3 min-w-0 flex-1">
+    <div class="ms-3 min-w-0 flex-1">
       <div class="flex items-start justify-between gap-2">
         <p
           class="text-foreground truncate text-sm font-medium"
@@ -106,7 +106,7 @@ import type { Notification, NotificationAction } from './notification-types';
     @if (showDismiss()) {
       <button
         type="button"
-        class="hover:bg-muted text-muted-foreground hover:text-foreground ml-2 shrink-0 rounded-full p-1 opacity-0 transition-all group-hover:opacity-100"
+        class="hover:bg-muted text-muted-foreground hover:text-foreground ms-2 shrink-0 rounded-full p-1 opacity-0 transition-all group-hover:opacity-100"
         (click)="onDismiss($event)"
         aria-label="Dismiss notification"
       >
@@ -137,7 +137,7 @@ export class ScNotificationItem {
 
   protected readonly class = computed(() =>
     cn(
-      'group relative flex items-start p-3 pr-2 rounded-lg cursor-pointer',
+      'group relative flex items-start p-3 pe-2 rounded-lg cursor-pointer',
       'hover:bg-muted/50 transition-colors',
       'focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
       !this.notification().read && 'bg-primary/5',

--- a/libs/ui-lab/src/lib/components/pdf-viewer/pdf-viewer-alt-text-dialog.ts
+++ b/libs/ui-lab/src/lib/components/pdf-viewer/pdf-viewer-alt-text-dialog.ts
@@ -44,13 +44,13 @@ import { SC_PDF_VIEWER } from './pdf-viewer-root';
               />
               Add a description
             </label>
-            <p class="mt-1 ml-6 text-xs text-gray-500">
+            <p class="ms-6 mt-1 text-xs text-gray-500">
               Aim for 1-2 sentences that describe the subject, setting, or
               actions.
             </p>
             @if (!isDecorative()) {
               <textarea
-                class="mt-2 ml-6 w-[calc(100%-1.5rem)] resize-none rounded border border-gray-300 bg-white p-2 text-sm text-gray-900 outline-none focus:border-blue-500"
+                class="ms-6 mt-2 w-[calc(100%-1.5rem)] resize-none rounded border border-gray-300 bg-white p-2 text-sm text-gray-900 outline-none focus:border-blue-500"
                 rows="3"
                 [placeholder]="'For example, “A young man sits down at a table to eat a meal”'"
                 [value]="altText()"
@@ -70,7 +70,7 @@ import { SC_PDF_VIEWER } from './pdf-viewer-root';
               />
               Mark as decorative
             </label>
-            <p class="mt-1 ml-6 text-xs text-gray-500">
+            <p class="ms-6 mt-1 text-xs text-gray-500">
               This is used for ornamental images, like borders or watermarks.
             </p>
           </div>

--- a/libs/ui-lab/src/lib/components/speed-dial/speed-dial-action-list.ts
+++ b/libs/ui-lab/src/lib/components/speed-dial/speed-dial-action-list.ts
@@ -21,8 +21,8 @@ export class ScSpeedDialActionList {
       'flex',
       dir === 'up' && 'flex-col-reverse items-center gap-3 mb-3',
       dir === 'down' && 'flex-col items-center gap-3 mt-3',
-      dir === 'left' && 'flex-row-reverse items-center gap-3 mr-3',
-      dir === 'right' && 'flex-row items-center gap-3 ml-3',
+      dir === 'left' && 'flex-row-reverse items-center gap-3 me-3',
+      dir === 'right' && 'flex-row items-center gap-3 ms-3',
       this.classInput(),
     );
   });

--- a/libs/ui-lab/src/lib/components/stepper/stepper-separator.ts
+++ b/libs/ui-lab/src/lib/components/stepper/stepper-separator.ts
@@ -26,7 +26,7 @@ export class ScStepperSeparator {
     const isVertical = this.stepper.orientation() === 'vertical';
     return cn(
       'transition-colors',
-      isVertical ? 'ml-5 h-8 w-0.5' : 'mt-5 h-0.5 flex-1',
+      isVertical ? 'ms-5 h-8 w-0.5' : 'mt-5 h-0.5 flex-1',
       'data-[state=complete]:bg-primary data-[state=inactive]:bg-muted',
       this.classInput(),
     );

--- a/libs/ui-lab/src/lib/components/tags-input/tags-input-clear.ts
+++ b/libs/ui-lab/src/lib/components/tags-input/tags-input-clear.ts
@@ -22,7 +22,7 @@ export class ScTagsInputClear {
   protected readonly class = computed(() =>
     cn(
       buttonVariants({ variant: 'ghost', size: 'icon-xs' }),
-      'ml-auto text-muted-foreground',
+      'ms-auto text-muted-foreground',
       this.classInput(),
     ),
   );

--- a/libs/ui-lab/src/lib/components/timeline/timeline-item.ts
+++ b/libs/ui-lab/src/lib/components/timeline/timeline-item.ts
@@ -15,6 +15,6 @@ export class ScTimelineItem {
   readonly classInput = input<string>('', { alias: 'class' });
 
   protected readonly class = computed(() =>
-    cn('relative pb-8 pl-8 last:pb-0', this.classInput()),
+    cn('relative pb-8 ps-8 last:pb-0', this.classInput()),
   );
 }

--- a/libs/ui-lab/src/lib/components/video-player/video-player-speed.ts
+++ b/libs/ui-lab/src/lib/components/video-player/video-player-speed.ts
@@ -69,7 +69,7 @@ export class ScVideoPlayerSpeed {
 
   protected getSpeedItemClass(speed: number): string {
     return cn(
-      'w-full cursor-default rounded-md px-3 py-1 text-left text-sm hover:bg-accent',
+      'w-full cursor-default rounded-md px-3 py-1 text-start text-sm hover:bg-accent',
       this.player.playbackRate() === speed && 'bg-accent',
     );
   }

--- a/libs/ui/src/lib/components/accordion/accordion-trigger.ts
+++ b/libs/ui/src/lib/components/accordion/accordion-trigger.ts
@@ -40,8 +40,8 @@ export class ScAccordionTrigger {
     cn(
       'focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring',
       '**:data-[slot=accordion-trigger-icon]:text-muted-foreground',
-      'rounded-lg py-2.5 text-left text-sm font-medium hover:underline focus-visible:ring-3',
-      '**:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4',
+      'rounded-lg py-2.5 text-start text-sm font-medium hover:underline focus-visible:ring-3',
+      '**:data-[slot=accordion-trigger-icon]:ms-auto **:data-[slot=accordion-trigger-icon]:size-4',
       'group/accordion-trigger relative flex flex-1 items-start justify-between',
       'border border-transparent transition-all outline-none',
       'aria-disabled:pointer-events-none aria-disabled:opacity-50',

--- a/libs/ui/src/lib/components/alert-dialog/alert-dialog-header.ts
+++ b/libs/ui/src/lib/components/alert-dialog/alert-dialog-header.ts
@@ -15,7 +15,7 @@ export class ScAlertDialogHeader {
       'grid grid-rows-[auto_1fr] place-items-center gap-1.5 text-center',
       'has-data-[slot=alert-dialog-media]:grid-rows-[auto_auto_1fr] has-data-[slot=alert-dialog-media]:gap-x-4',
       'sm:group-data-[size=default]/alert-dialog-content:place-items-start',
-      'sm:group-data-[size=default]/alert-dialog-content:text-left',
+      'sm:group-data-[size=default]/alert-dialog-content:text-start',
       'sm:group-data-[size=default]/alert-dialog-content:has-data-[slot=alert-dialog-media]:grid-rows-[auto_1fr]',
       this.classInput(),
     ),

--- a/libs/ui/src/lib/components/alert/alert.ts
+++ b/libs/ui/src/lib/components/alert/alert.ts
@@ -3,7 +3,7 @@ import { type VariantProps, cva } from 'class-variance-authority';
 import { cn } from '../../utils';
 
 const alertVariants = cva(
-  "grid gap-0.5 rounded-lg border px-2.5 py-2 text-left text-sm has-data-[slot=alert-action]:relative has-data-[slot=alert-action]:pr-18 has-[>svg]:grid-cols-[auto_1fr] has-[>svg]:gap-x-2 *:[svg]:row-span-2 *:[svg]:translate-y-0.5 *:[svg]:text-current *:[svg:not([class*='size-'])]:size-4 w-full relative group/alert",
+  "grid gap-0.5 rounded-lg border px-2.5 py-2 text-start text-sm has-data-[slot=alert-action]:relative has-data-[slot=alert-action]:pe-18 has-[>svg]:grid-cols-[auto_1fr] has-[>svg]:gap-x-2 *:[svg]:row-span-2 *:[svg]:translate-y-0.5 *:[svg]:text-current *:[svg:not([class*='size-'])]:size-4 w-full relative group/alert",
   {
     variants: {
       variant: {

--- a/libs/ui/src/lib/components/avatar/avatar-group.ts
+++ b/libs/ui/src/lib/components/avatar/avatar-group.ts
@@ -12,7 +12,7 @@ export class ScAvatarGroup {
 
   protected readonly class = computed(() =>
     cn(
-      '*:data-[slot=avatar]:ring-background group/avatar-group flex -space-x-2 *:data-[slot=avatar]:ring-2',
+      '*:data-[slot=avatar]:ring-background group/avatar-group flex -space-x-2 rtl:space-x-reverse *:data-[slot=avatar]:ring-2',
       this.classInput(),
     ),
   );

--- a/libs/ui/src/lib/components/badge/badge.ts
+++ b/libs/ui/src/lib/components/badge/badge.ts
@@ -3,7 +3,7 @@ import { VariantProps, cva } from 'class-variance-authority';
 import { cn } from '../../utils';
 
 export const badgeVariants = cva(
-  'group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-4xl border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!',
+  'group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-4xl border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pe-1.5 has-data-[icon=inline-start]:ps-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!',
   {
     variants: {
       variant: {

--- a/libs/ui/src/lib/components/button-group/button-group.ts
+++ b/libs/ui/src/lib/components/button-group/button-group.ts
@@ -3,12 +3,12 @@ import { type VariantProps, cva } from 'class-variance-authority';
 import { cn } from '../../utils';
 
 export const buttonGroupVariants = cva(
-  "has-[>[data-slot=button-group]]:gap-2 has-[select[aria-hidden=true]:last-child]:[&>[data-slot=select-input-group]:last-of-type]:rounded-r-lg flex w-fit items-stretch *:focus-visible:z-10 *:focus-visible:relative [&>[data-slot=select-input-group]:not([class*='w-'])]:w-fit [&>input]:flex-1",
+  "has-[>[data-slot=button-group]]:gap-2 has-[select[aria-hidden=true]:last-child]:[&>[data-slot=select-input-group]:last-of-type]:rounded-e-lg flex w-fit items-stretch *:focus-visible:z-10 *:focus-visible:relative [&>[data-slot=select-input-group]:not([class*='w-'])]:w-fit [&>input]:flex-1",
   {
     variants: {
       orientation: {
         horizontal:
-          '[&>[data-slot]:not(:has(~[data-slot]))]:rounded-r-lg! [&>*:not(:first-child)]:rounded-l-none [&>*:not(:first-child)]:border-l-0 [&>*:not(:last-child)]:rounded-r-none',
+          '[&>[data-slot]:not(:has(~[data-slot]))]:rounded-e-lg! [&>*:not(:first-child)]:rounded-s-none [&>*:not(:first-child)]:border-s-0 [&>*:not(:last-child)]:rounded-e-none',
         vertical:
           '[&>[data-slot]:not(:has(~[data-slot]))]:rounded-b-lg! flex-col [&>*:not(:first-child)]:rounded-t-none [&>*:not(:first-child)]:border-t-0 [&>*:not(:last-child)]:rounded-b-none',
       },

--- a/libs/ui/src/lib/components/combobox/combobox-input.ts
+++ b/libs/ui/src/lib/components/combobox/combobox-input.ts
@@ -16,7 +16,7 @@ export class ScComboboxInput {
 
   protected readonly class = computed(() =>
     cn(
-      'absolute inset-0 h-full w-full cursor-pointer border-none bg-transparent pl-2.5 outline-none placeholder:text-muted-foreground',
+      'absolute inset-0 h-full w-full cursor-pointer border-none bg-transparent ps-2.5 outline-none placeholder:text-muted-foreground',
       this.combobox.hasValue() && 'opacity-0',
       this.classInput(),
     ),

--- a/libs/ui/src/lib/components/drawer/drawer-header.ts
+++ b/libs/ui/src/lib/components/drawer/drawer-header.ts
@@ -12,7 +12,7 @@ export class ScDrawerHeader {
 
   protected readonly class = computed(() =>
     cn(
-      'gap-0.5 p-4 group-data-[direction=bottom]/drawer:text-center group-data-[direction=top]/drawer:text-center md:gap-0.5 md:text-left flex flex-col',
+      'gap-0.5 p-4 group-data-[direction=bottom]/drawer:text-center group-data-[direction=top]/drawer:text-center md:gap-0.5 md:text-start flex flex-col',
       this.classInput(),
     ),
   );

--- a/libs/ui/src/lib/components/field/field-description.ts
+++ b/libs/ui/src/lib/components/field/field-description.ts
@@ -44,7 +44,7 @@ export class ScFieldDescription {
 
   protected readonly class = computed(() =>
     cn(
-      'text-muted-foreground text-left text-sm [[data-variant=legend]+&]:-mt-1.5 leading-normal font-normal group-has-data-[orientation=horizontal]/field:text-balance',
+      'text-muted-foreground text-start text-sm [[data-variant=legend]+&]:-mt-1.5 leading-normal font-normal group-has-data-[orientation=horizontal]/field:text-balance',
       'last:mt-0 nth-last-2:-mt-1',
       '[&>a:hover]:text-primary [&>a]:underline [&>a]:underline-offset-4',
       this.classInput(),

--- a/libs/ui/src/lib/components/field/field-errors.ts
+++ b/libs/ui/src/lib/components/field/field-errors.ts
@@ -17,7 +17,7 @@ import { SC_FIELD } from './field';
     @if (errors().length === 1) {
       {{ errors()[0].message }}
     } @else if (errors().length > 1) {
-      <ul class="ml-4 flex list-disc flex-col gap-1">
+      <ul class="ms-4 flex list-disc flex-col gap-1">
         @for (error of errors(); track error.message) {
           <li>{{ error.message }}</li>
         }

--- a/libs/ui/src/lib/components/item/item-description.ts
+++ b/libs/ui/src/lib/components/item/item-description.ts
@@ -13,7 +13,7 @@ export class ScItemDescription {
 
   protected readonly class = computed(() =>
     cn(
-      'text-muted-foreground text-left text-sm leading-normal group-data-[size=xs]/item:text-xs [&>a:hover]:text-primary line-clamp-2 font-normal [&>a]:underline [&>a]:underline-offset-4',
+      'text-muted-foreground text-start text-sm leading-normal group-data-[size=xs]/item:text-xs [&>a:hover]:text-primary line-clamp-2 font-normal [&>a]:underline [&>a]:underline-offset-4',
       this.classInput(),
     ),
   );

--- a/libs/ui/src/lib/components/native-select/native-select.ts
+++ b/libs/ui/src/lib/components/native-select/native-select.ts
@@ -34,7 +34,7 @@ export class ScNativeSelect {
 
   protected readonly class = computed(() =>
     cn(
-      'border-input placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 dark:hover:bg-input/50 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 h-8 w-full min-w-0 appearance-none rounded-lg border bg-transparent py-1 pr-8 pl-2.5 text-sm transition-colors select-none focus-visible:ring-3 aria-invalid:ring-3 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] data-[size=sm]:py-0.5 outline-none disabled:pointer-events-none disabled:cursor-not-allowed',
+      'border-input placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 dark:hover:bg-input/50 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 h-8 w-full min-w-0 appearance-none rounded-lg border bg-transparent py-1 pe-8 ps-2.5 text-sm transition-colors select-none focus-visible:ring-3 aria-invalid:ring-3 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] data-[size=sm]:py-0.5 outline-none disabled:pointer-events-none disabled:cursor-not-allowed',
       this.classInput(),
     ),
   );

--- a/libs/ui/src/lib/components/navigation-menu/navigation-menu-trigger-icon.ts
+++ b/libs/ui/src/lib/components/navigation-menu/navigation-menu-trigger-icon.ts
@@ -15,7 +15,7 @@ export class ScNavigationMenuTriggerIcon {
 
   protected readonly class = computed(() =>
     cn(
-      'relative top-px ml-1 size-3 transition duration-300',
+      'relative top-px ms-1 size-3 transition duration-300',
       this.menuItem.open() && 'rotate-180',
       this.classInput(),
     ),

--- a/libs/ui/src/lib/components/otp/otp-slot.ts
+++ b/libs/ui/src/lib/components/otp/otp-slot.ts
@@ -63,7 +63,7 @@ export class ScOtpSlot {
 
   protected readonly class = computed(() =>
     cn(
-      'relative flex h-10 w-10 items-center justify-center border-y border-r border-input text-sm transition-all first:rounded-l-md first:border-l last:rounded-r-md',
+      'relative flex h-10 w-10 items-center justify-center border-y border-e border-input text-sm transition-all first:rounded-s-md first:border-s last:rounded-e-md',
       this.isActive() && 'z-10 ring-2 ring-ring ring-offset-background',
       this.classInput(),
     ),

--- a/libs/ui/src/lib/components/pagination/pagination-next.ts
+++ b/libs/ui/src/lib/components/pagination/pagination-next.ts
@@ -49,7 +49,7 @@ export class ScPaginationNext {
   protected readonly class = computed(() =>
     cn(
       buttonVariants({ variant: this.variant(), size: this.size() }),
-      'pr-1.5',
+      'pe-1.5',
       this.classInput(),
     ),
   );

--- a/libs/ui/src/lib/components/pagination/pagination-previous.ts
+++ b/libs/ui/src/lib/components/pagination/pagination-previous.ts
@@ -49,7 +49,7 @@ export class ScPaginationPrevious {
   protected readonly class = computed(() =>
     cn(
       buttonVariants({ variant: this.variant(), size: this.size() }),
-      'pl-1.5',
+      'ps-1.5',
       this.classInput(),
     ),
   );

--- a/libs/ui/src/lib/components/select/select-icon.ts
+++ b/libs/ui/src/lib/components/select/select-icon.ts
@@ -15,7 +15,7 @@ export class ScSelectIcon {
 
   protected readonly class = computed(() =>
     cn(
-      'text-muted-foreground pointer-events-none ml-auto size-4 shrink-0 transition-transform duration-150',
+      'text-muted-foreground pointer-events-none ms-auto size-4 shrink-0 transition-transform duration-150',
       this.combobox.expanded() && 'rotate-180',
       this.classInput(),
     ),

--- a/libs/ui/src/lib/components/select/select-input.ts
+++ b/libs/ui/src/lib/components/select/select-input.ts
@@ -27,7 +27,7 @@ export class ScSelectInput {
 
   protected readonly class = computed(() =>
     cn(
-      'absolute inset-0 h-full w-full cursor-pointer border-none bg-transparent pl-2.5 outline-none placeholder:text-muted-foreground',
+      'absolute inset-0 h-full w-full cursor-pointer border-none bg-transparent ps-2.5 outline-none placeholder:text-muted-foreground',
       this.hasValue() && 'opacity-0',
       this.classInput(),
     ),

--- a/libs/ui/src/lib/components/select/select-item.ts
+++ b/libs/ui/src/lib/components/select/select-item.ts
@@ -50,7 +50,7 @@ export class ScSelectItem {
 
   protected readonly class = computed(() =>
     cn(
-      'relative flex w-full cursor-default select-none items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden',
+      'relative flex w-full cursor-default select-none items-center gap-1.5 rounded-md py-1 pe-8 ps-1.5 text-sm outline-hidden',
       'data-[active=true]:bg-accent data-[active=true]:text-accent-foreground',
       'aria-selected:bg-accent/50 aria-selected:text-accent-foreground',
       'data-disabled:pointer-events-none data-disabled:opacity-50',

--- a/libs/ui/src/lib/components/sheet/sheet-header.ts
+++ b/libs/ui/src/lib/components/sheet/sheet-header.ts
@@ -11,6 +11,6 @@ export class ScSheetHeader {
   readonly classInput = input<string>('', { alias: 'class' });
 
   protected readonly class = computed(() =>
-    cn('flex flex-col gap-2 text-center sm:text-left', this.classInput()),
+    cn('flex flex-col gap-2 text-center sm:text-start', this.classInput()),
   );
 }

--- a/libs/ui/src/lib/components/table/table-cell.ts
+++ b/libs/ui/src/lib/components/table/table-cell.ts
@@ -11,6 +11,6 @@ export class ScTableCell {
   readonly classInput = input<string>('', { alias: 'class' });
 
   protected readonly class = computed(() =>
-    cn('p-4 align-middle [&:has([role=checkbox])]:pr-0', this.classInput()),
+    cn('p-4 align-middle [&:has([role=checkbox])]:pe-0', this.classInput()),
   );
 }

--- a/libs/ui/src/lib/components/table/table-header-cell.ts
+++ b/libs/ui/src/lib/components/table/table-header-cell.ts
@@ -12,7 +12,7 @@ export class ScTableHeaderCell {
 
   protected readonly class = computed(() =>
     cn(
-      'h-12 px-4 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0',
+      'h-12 px-4 text-start align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pe-0',
       this.classInput(),
     ),
   );

--- a/libs/ui/src/lib/components/time-picker/time-picker-period.ts
+++ b/libs/ui/src/lib/components/time-picker/time-picker-period.ts
@@ -17,7 +17,7 @@ export class ScTimePickerPeriod {
 
   protected readonly class = computed(() =>
     cn(
-      'ml-2 inline-flex rounded-md border border-input bg-background p-0.5',
+      'ms-2 inline-flex rounded-md border border-input bg-background p-0.5',
       this.classInput(),
     ),
   );

--- a/libs/ui/src/lib/components/toast/toast.ts
+++ b/libs/ui/src/lib/components/toast/toast.ts
@@ -36,7 +36,7 @@ export class ScToast {
 
   protected readonly class = computed(() =>
     cn(
-      'group pointer-events-auto relative flex w-full items-center justify-between gap-4 overflow-hidden rounded-md border p-4 pr-6 shadow-lg transition-all',
+      'group pointer-events-auto relative flex w-full items-center justify-between gap-4 overflow-hidden rounded-md border p-4 pe-6 shadow-lg transition-all',
       'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full',
       this.position().startsWith('bottom')
         ? 'data-[state=open]:slide-in-from-bottom-full'

--- a/libs/ui/src/lib/components/toggle-group/toggle-group-item.ts
+++ b/libs/ui/src/lib/components/toggle-group/toggle-group-item.ts
@@ -36,7 +36,7 @@ export class ScToggleGroupItem {
 
   protected readonly class = computed(() =>
     cn(
-      'group-data-[spacing=0]/toggle-group:rounded-none group-data-[spacing=0]/toggle-group:px-2 group-data-horizontal/toggle-group:data-[spacing=0]:first:rounded-l-lg group-data-vertical/toggle-group:data-[spacing=0]:first:rounded-t-lg group-data-horizontal/toggle-group:data-[spacing=0]:last:rounded-r-lg group-data-vertical/toggle-group:data-[spacing=0]:last:rounded-b-lg shrink-0 focus:z-10 focus-visible:z-10 group-data-horizontal/toggle-group:data-[spacing=0]:data-[variant=outline]:border-l-0 group-data-vertical/toggle-group:data-[spacing=0]:data-[variant=outline]:border-t-0 group-data-horizontal/toggle-group:data-[spacing=0]:data-[variant=outline]:first:border-l group-data-vertical/toggle-group:data-[spacing=0]:data-[variant=outline]:first:border-t',
+      'group-data-[spacing=0]/toggle-group:rounded-none group-data-[spacing=0]/toggle-group:px-2 group-data-horizontal/toggle-group:data-[spacing=0]:first:rounded-s-lg group-data-vertical/toggle-group:data-[spacing=0]:first:rounded-t-lg group-data-horizontal/toggle-group:data-[spacing=0]:last:rounded-e-lg group-data-vertical/toggle-group:data-[spacing=0]:last:rounded-b-lg shrink-0 focus:z-10 focus-visible:z-10 group-data-horizontal/toggle-group:data-[spacing=0]:data-[variant=outline]:border-s-0 group-data-vertical/toggle-group:data-[spacing=0]:data-[variant=outline]:border-t-0 group-data-horizontal/toggle-group:data-[spacing=0]:data-[variant=outline]:first:border-s group-data-vertical/toggle-group:data-[spacing=0]:data-[variant=outline]:first:border-t',
       toggleVariants({
         variant: this.group.variant() || this.variant(),
         size: this.group.size() || this.size(),


### PR DESCRIPTION
Applies shadcn's physical → logical mapping (`packages/shadcn/src/utils/transformers/transform-rtl.ts`) across `libs`. Upstream keeps physical properties in source and generates an RTL variant at build time; we write the transformed form directly, so **a physical property left in our code is a bug**, not a style choice.

**44 files, 55 lines**, all mechanical:

| From | To | | From | To |
|---|---|---|---|---|
| `text-left` | `text-start` | | `ml-` | `ms-` |
| `text-right` | `text-end` | | `mr-` | `me-` |
| `border-l` | `border-s` | | `pl-` | `ps-` |
| `border-r` | `border-e` | | `pr-` | `pe-` |
| `rounded-l-` | `rounded-s-` | | `rounded-r-` | `rounded-e-` |

`space-x-*` has no logical equivalent, so it gets an explicit `rtl:space-x-reverse` — one of the four non-rename rules in upstream's table.

This also fixes **badge**, whose icon padding was copied verbatim from `.cn-badge` as `pr-1.5`/`pl-1.5` and padded the wrong side in RTL.

## Left physical deliberately

- **`drawer` and `sheet`** key their borders off an explicit `data-[direction=left]` / `data-[side=left]` API. There "left" means literally left, and the border must sit on the opposite physical edge — making it logical would put it on the wrong side in RTL.
- **`image-cropper-handle`** positions are paired with matching physical resize cursors (`w-resize`, `sw-resize`). Flipping position without the cursor breaks it; flipping both mirrors a spatial widget for no reason.

## Not covered

- **71 absolute-positioning `left-*`/`right-*` utilities.** 20 sit inside physical `data-[side=…]` variants; the rest need case-by-case review. Mechanically flipping them would break the ones that are deliberately physical.
- **Directional icons.** Upstream marks them `cn-rtl-flip`, which its transform turns into `rtl:rotate-180` — chevrons and arrows in pagination, carousel, breadcrumb. We have no `rtl:rotate-180` anywhere, so these don't flip. We do already hand-apply other parts of the transform (`rtl:translate-x-*` in sidebar/carousel, `rtl:` cursor swaps in `sidebar-rail`), so this reads as an omission rather than a decision.

## Verification

- Every removed token pairs with an added one — 12 `text-left` → 12 `text-start`, 5 `border-r` → 5 `border-e`, etc.
- After the pass, the only physical properties left in `libs` are the deliberate `drawer`/`sheet` side-keyed lines.
- `nx lint` clean across `ui`, `ui-lab`, `carousel`, `code`; **32 warnings before and after**, compared against a `git stash` baseline rather than assumed.
- `tsc --noEmit` exit 0 for `ui` and `ui-lab`; `validate-demo-code` 0 mismatches; 18/18 tests pass.

Tests don't assert computed classes, so they say little here — this needs a look in RTL. `docs/shadcn-style-reference.md` (#1505) covers how to check the remaining categories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)