### PR TITLE
fix(rtl): flip directional icons

### DIFF
--- a/libs/carousel/src/lib/components/carousel/carousel-next.ts
+++ b/libs/carousel/src/lib/components/carousel/carousel-next.ts
@@ -36,7 +36,7 @@ export class ScCarouselNext {
       buttonVariants({ variant: this.variant(), size: this.size() }),
       'rounded-full absolute touch-manipulation',
       isHorizontal
-        ? '-end-12 top-1/2 -translate-y-1/2'
+        ? '-end-12 top-1/2 -translate-y-1/2 rtl:[&>svg]:rotate-180'
         : 'start-1/2 -bottom-12 -translate-x-1/2 rotate-90 rtl:translate-x-1/2',
       this.classInput(),
     );

--- a/libs/carousel/src/lib/components/carousel/carousel-previous.ts
+++ b/libs/carousel/src/lib/components/carousel/carousel-previous.ts
@@ -36,7 +36,7 @@ export class ScCarouselPrevious {
       buttonVariants({ variant: this.variant(), size: this.size() }),
       'rounded-full absolute touch-manipulation',
       isHorizontal
-        ? '-start-12 top-1/2 -translate-y-1/2'
+        ? '-start-12 top-1/2 -translate-y-1/2 rtl:[&>svg]:rotate-180'
         : 'start-1/2 -top-12 -translate-x-1/2 rotate-90 rtl:translate-x-1/2',
       this.classInput(),
     );

--- a/libs/ui-lab/src/lib/components/data-table/data-table-pagination.ts
+++ b/libs/ui-lab/src/lib/components/data-table/data-table-pagination.ts
@@ -59,7 +59,7 @@ import { SC_DATA_TABLE } from './data-table';
             (click)="goToPage(1)"
             aria-label="First page"
           >
-            <svg siChevronsLeftIcon class="size-4"></svg>
+            <svg siChevronsLeftIcon class="size-4 rtl:rotate-180"></svg>
           </button>
           <button
             type="button"
@@ -68,7 +68,7 @@ import { SC_DATA_TABLE } from './data-table';
             (click)="goToPage(currentPage() - 1)"
             aria-label="Previous page"
           >
-            <svg siChevronLeftIcon class="size-4"></svg>
+            <svg siChevronLeftIcon class="size-4 rtl:rotate-180"></svg>
           </button>
           <button
             type="button"
@@ -77,7 +77,7 @@ import { SC_DATA_TABLE } from './data-table';
             (click)="goToPage(currentPage() + 1)"
             aria-label="Next page"
           >
-            <svg siChevronRightIcon class="size-4"></svg>
+            <svg siChevronRightIcon class="size-4 rtl:rotate-180"></svg>
           </button>
           <button
             type="button"
@@ -86,7 +86,7 @@ import { SC_DATA_TABLE } from './data-table';
             (click)="goToPage(totalPages())"
             aria-label="Last page"
           >
-            <svg siChevronsRightIcon class="size-4"></svg>
+            <svg siChevronsRightIcon class="size-4 rtl:rotate-180"></svg>
           </button>
         </div>
       </div>

--- a/libs/ui-lab/src/lib/components/transfer-list/transfer-list-actions.ts
+++ b/libs/ui-lab/src/lib/components/transfer-list/transfer-list-actions.ts
@@ -30,7 +30,7 @@ import { ScTransferListState } from './transfer-list-state';
       (click)="state.moveToTarget()"
       aria-label="Move selected to right"
     >
-      <svg siChevronRightIcon class="size-[18px]"></svg>
+      <svg siChevronRightIcon class="size-[18px] rtl:rotate-180"></svg>
     </button>
     <button
       type="button"
@@ -39,7 +39,7 @@ import { ScTransferListState } from './transfer-list-state';
       (click)="state.moveToSource()"
       aria-label="Move selected to left"
     >
-      <svg siChevronLeftIcon class="size-[18px]"></svg>
+      <svg siChevronLeftIcon class="size-[18px] rtl:rotate-180"></svg>
     </button>
     <button
       type="button"
@@ -48,7 +48,7 @@ import { ScTransferListState } from './transfer-list-state';
       (click)="state.moveAllToTarget()"
       aria-label="Move all to right"
     >
-      <svg siChevronsRightIcon class="size-[18px]"></svg>
+      <svg siChevronsRightIcon class="size-[18px] rtl:rotate-180"></svg>
     </button>
     <button
       type="button"
@@ -57,7 +57,7 @@ import { ScTransferListState } from './transfer-list-state';
       (click)="state.moveAllToSource()"
       aria-label="Move all to left"
     >
-      <svg siChevronsLeftIcon class="size-[18px]"></svg>
+      <svg siChevronsLeftIcon class="size-[18px] rtl:rotate-180"></svg>
     </button>
   `,
   host: {

--- a/libs/ui/src/lib/components/pagination/pagination-first.ts
+++ b/libs/ui/src/lib/components/pagination/pagination-first.ts
@@ -49,6 +49,7 @@ export class ScPaginationFirst {
   protected readonly class = computed(() =>
     cn(
       buttonVariants({ variant: this.variant(), size: this.size() }),
+      'rtl:[&>svg]:rotate-180',
       this.classInput(),
     ),
   );

--- a/libs/ui/src/lib/components/pagination/pagination-last.ts
+++ b/libs/ui/src/lib/components/pagination/pagination-last.ts
@@ -49,6 +49,7 @@ export class ScPaginationLast {
   protected readonly class = computed(() =>
     cn(
       buttonVariants({ variant: this.variant(), size: this.size() }),
+      'rtl:[&>svg]:rotate-180',
       this.classInput(),
     ),
   );

--- a/libs/ui/src/lib/components/pagination/pagination-next.ts
+++ b/libs/ui/src/lib/components/pagination/pagination-next.ts
@@ -50,6 +50,7 @@ export class ScPaginationNext {
     cn(
       buttonVariants({ variant: this.variant(), size: this.size() }),
       'pe-1.5',
+      'rtl:[&>svg]:rotate-180',
       this.classInput(),
     ),
   );

--- a/libs/ui/src/lib/components/pagination/pagination-previous.ts
+++ b/libs/ui/src/lib/components/pagination/pagination-previous.ts
@@ -50,6 +50,7 @@ export class ScPaginationPrevious {
     cn(
       buttonVariants({ variant: this.variant(), size: this.size() }),
       'ps-1.5',
+      'rtl:[&>svg]:rotate-180',
       this.classInput(),
     ),
   );


### PR DESCRIPTION
Upstream marks left/right chevrons with `cn-rtl-flip`, which its RTL build turns into `rtl:rotate-180`. **We had no `rtl:rotate-180` anywhere**, so every directional chevron pointed the wrong way in RTL — the most visible of the remaining RTL gaps.

## Two shapes of fix

**Icon projected by the consumer** → flip on the host, scoped to the child:

| Component | Class |
|---|---|
| `pagination-first` / `-last` / `-next` / `-previous` | `rtl:[&>svg]:rotate-180` |
| `carousel-next` / `-previous` (horizontal only) | `rtl:[&>svg]:rotate-180` |

**Icon rendered by us** → flip on the `<svg>` directly: `data-table-pagination` (4 icons) and `transfer-list-actions` (4 icons).

Carousel flips only in its horizontal branch. The vertical branch already applies `rotate-90` so the chevrons point up/down, where a 180° flip would be wrong.

## Left alone deliberately

- **`breadcrumb-separator`** projects arbitrary content, and our demos use both a chevron (18×) and a slash (4×). A host-level flip would turn the slashes into backslashes. Upstream has the same split and marks only its chevron, never its slash — so this belongs on the projected icon, not the container.
- **`image-compare-slider`** is a spatial widget whose handle icons are paired with physical positions (including `rotate-90` / `-rotate-90` variants).

## Verification

Both variants compiled through the repo's Tailwind to confirm the selector:

```css
.rtl\:rotate-180:where(:dir(rtl), [dir="rtl"], [dir="rtl"] *) { rotate: 180deg }
.rtl\:\[\&\>svg\]\:rotate-180:where(:dir(rtl), …) > svg { rotate: 180deg }
```

`nx lint` clean across `ui`, `ui-lab`, `carousel` (32 warnings, unchanged); `tsc --noEmit` exit 0; `validate-demo-code` 0 mismatches; 18/18 tests.

Nothing asserts computed classes, so this wants a look with `dir="rtl"` on the pagination, carousel, data-table and transfer-list demos.

## Remaining RTL work

The 71 absolute-positioning `left-*`/`right-*` utilities. 20 sit inside physical `data-[side=…]` variants that should stay physical; the rest need case-by-case review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)