### PR TITLE
fix(rtl): use logical insets for single-edge UI affordances

### DIFF
--- a/libs/ui-lab/src/lib/components/data-table/data-table-column-toggle.ts
+++ b/libs/ui-lab/src/lib/components/data-table/data-table-column-toggle.ts
@@ -25,7 +25,7 @@ import { SC_DATA_TABLE } from './data-table';
 
     @if (isOpen()) {
       <div
-        class="bg-popover absolute top-full right-0 z-50 mt-2 min-w-[150px] rounded-md border p-2 shadow-md"
+        class="bg-popover absolute end-0 top-full z-50 mt-2 min-w-[150px] rounded-md border p-2 shadow-md"
       >
         @for (column of table.columns(); track column.id) {
           @if (column.enableHiding !== false) {

--- a/libs/ui-lab/src/lib/components/dock/dock-badge.ts
+++ b/libs/ui-lab/src/lib/components/dock/dock-badge.ts
@@ -12,7 +12,7 @@ export class ScDockBadge {
 
   protected readonly class = computed(() =>
     cn(
-      'absolute -top-1 -right-1',
+      'absolute -top-1 -end-1',
       'min-w-[18px] h-[18px] px-1',
       'flex items-center justify-center',
       'text-[10px] font-medium',

--- a/libs/ui-lab/src/lib/components/lightbox/lightbox-close.ts
+++ b/libs/ui-lab/src/lib/components/lightbox/lightbox-close.ts
@@ -17,7 +17,7 @@ export class ScLightboxClose {
 
   protected readonly class = computed(() =>
     cn(
-      "absolute top-4 right-4 z-10 inline-flex size-10 items-center justify-center rounded-full text-white/80 hover:bg-white/10 hover:text-white [&_svg:not([class*='size-'])]:size-6",
+      "absolute top-4 end-4 z-10 inline-flex size-10 items-center justify-center rounded-full text-white/80 hover:bg-white/10 hover:text-white [&_svg:not([class*='size-'])]:size-6",
       this.classInput(),
     ),
   );

--- a/libs/ui-lab/src/lib/components/lightbox/lightbox-next.ts
+++ b/libs/ui-lab/src/lib/components/lightbox/lightbox-next.ts
@@ -21,7 +21,7 @@ export class ScLightboxNext {
 
   protected readonly class = computed(() =>
     cn(
-      "absolute top-1/2 right-4 z-10 inline-flex size-10 -translate-y-1/2 items-center justify-center rounded-full text-white/80 hover:bg-white/10 hover:text-white disabled:cursor-not-allowed disabled:opacity-30 [&_svg:not([class*='size-'])]:size-6",
+      "absolute top-1/2 end-4 z-10 inline-flex size-10 -translate-y-1/2 items-center justify-center rounded-full text-white/80 hover:bg-white/10 hover:text-white disabled:cursor-not-allowed disabled:opacity-30 [&_svg:not([class*='size-'])]:size-6",
       this.classInput(),
     ),
   );

--- a/libs/ui-lab/src/lib/components/lightbox/lightbox-prev.ts
+++ b/libs/ui-lab/src/lib/components/lightbox/lightbox-prev.ts
@@ -21,7 +21,7 @@ export class ScLightboxPrev {
 
   protected readonly class = computed(() =>
     cn(
-      "absolute top-1/2 left-4 z-10 inline-flex size-10 -translate-y-1/2 items-center justify-center rounded-full text-white/80 hover:bg-white/10 hover:text-white disabled:cursor-not-allowed disabled:opacity-30 [&_svg:not([class*='size-'])]:size-6",
+      "absolute top-1/2 start-4 z-10 inline-flex size-10 -translate-y-1/2 items-center justify-center rounded-full text-white/80 hover:bg-white/10 hover:text-white disabled:cursor-not-allowed disabled:opacity-30 [&_svg:not([class*='size-'])]:size-6",
       this.classInput(),
     ),
   );

--- a/libs/ui-lab/src/lib/components/native-dialog/native-dialog-close.ts
+++ b/libs/ui-lab/src/lib/components/native-dialog/native-dialog-close.ts
@@ -20,7 +20,7 @@ export class ScNativeDialogClose {
   protected readonly class = computed(() =>
     cn(
       buttonVariants({ variant: this.variant(), size: this.size() }),
-      'absolute top-2 right-2',
+      'absolute top-2 end-2',
       this.classInput(),
     ),
   );

--- a/libs/ui-lab/src/lib/components/notification-center/notification-item.ts
+++ b/libs/ui-lab/src/lib/components/notification-center/notification-item.ts
@@ -30,7 +30,7 @@ import type { Notification, NotificationAction } from './notification-types';
     <!-- Unread indicator -->
     @if (!notification().read) {
       <div
-        class="bg-primary absolute top-1/2 left-2 h-2 w-2 -translate-y-1/2 rounded-full"
+        class="bg-primary absolute start-2 top-1/2 h-2 w-2 -translate-y-1/2 rounded-full"
         aria-label="Unread"
       ></div>
     }

--- a/libs/ui-lab/src/lib/components/signature-pad/signature-pad-controls.ts
+++ b/libs/ui-lab/src/lib/components/signature-pad/signature-pad-controls.ts
@@ -11,6 +11,6 @@ export class ScSignaturePadControls {
   readonly classInput = input<string>('', { alias: 'class' });
 
   protected readonly class = computed(() =>
-    cn('absolute top-2 right-2 flex gap-1', this.classInput()),
+    cn('absolute top-2 end-2 flex gap-1', this.classInput()),
   );
 }

--- a/libs/ui-lab/src/lib/components/spotlight/spotlight-close.ts
+++ b/libs/ui-lab/src/lib/components/spotlight/spotlight-close.ts
@@ -17,7 +17,7 @@ export class ScSpotlightClose {
 
   protected readonly class = computed(() =>
     cn(
-      'bg-background/90 hover:bg-background text-foreground absolute top-4 right-4 z-10 rounded-full p-2 shadow-lg',
+      'bg-background/90 hover:bg-background text-foreground absolute top-4 end-4 z-10 rounded-full p-2 shadow-lg',
       this.classInput(),
     ),
   );

--- a/libs/ui-lab/src/lib/components/timeline/timeline-dot.ts
+++ b/libs/ui-lab/src/lib/components/timeline/timeline-dot.ts
@@ -20,7 +20,7 @@ export class ScTimelineDot {
 
   protected readonly class = computed(() =>
     cn(
-      'absolute left-0 flex items-center justify-center rounded-full',
+      'absolute start-0 flex items-center justify-center rounded-full',
       // Size
       this.size() === 'sm' && 'size-4 top-1',
       this.size() === 'default' && 'size-6 top-0',

--- a/libs/ui-lab/src/lib/components/tour-guide/tour-guide-close.ts
+++ b/libs/ui-lab/src/lib/components/tour-guide/tour-guide-close.ts
@@ -16,6 +16,6 @@ export class ScTourGuideClose {
   protected readonly state = inject(ScTourGuideState);
 
   protected readonly class = computed(() =>
-    cn('hover:bg-accent absolute top-2 right-2 rounded p-1', this.classInput()),
+    cn('hover:bg-accent absolute top-2 end-2 rounded p-1', this.classInput()),
   );
 }

--- a/libs/ui-lab/src/lib/components/tour-guide/tour-guide-step-number.ts
+++ b/libs/ui-lab/src/lib/components/tour-guide/tour-guide-step-number.ts
@@ -20,7 +20,7 @@ export class ScTourGuideStepNumber {
 
   protected readonly class = computed(() =>
     cn(
-      'bg-primary text-primary-foreground absolute -top-3 -left-3 flex size-6 items-center justify-center rounded-full text-xs font-medium',
+      'bg-primary text-primary-foreground absolute -top-3 -start-3 flex size-6 items-center justify-center rounded-full text-xs font-medium',
       this.classInput(),
     ),
   );

--- a/libs/ui/src/lib/components/alert/alert-action.ts
+++ b/libs/ui/src/lib/components/alert/alert-action.ts
@@ -12,6 +12,6 @@ export class ScAlertAction {
   readonly classInput = input<string>('', { alias: 'class' });
 
   protected readonly class = computed(() =>
-    cn('absolute top-2 right-2', this.classInput()),
+    cn('absolute top-2 end-2', this.classInput()),
   );
 }

--- a/libs/ui/src/lib/components/avatar/avatar-badge.ts
+++ b/libs/ui/src/lib/components/avatar/avatar-badge.ts
@@ -12,7 +12,7 @@ export class ScAvatarBadge {
 
   protected readonly class = computed(() =>
     cn(
-      'bg-primary text-primary-foreground ring-background absolute right-0 bottom-0 z-10 size-2.5 inline-flex items-center justify-center rounded-full ring-2 select-none [&>svg]:size-2',
+      'bg-primary text-primary-foreground ring-background absolute end-0 bottom-0 z-10 size-2.5 inline-flex items-center justify-center rounded-full ring-2 select-none [&>svg]:size-2',
       'group-data-[size=sm]/avatar:size-2 group-data-[size=sm]/avatar:[&>svg]:hidden',
       'group-data-[size=lg]/avatar:size-3',
       this.classInput(),

--- a/libs/ui/src/lib/components/calendar/calendar-next.ts
+++ b/libs/ui/src/lib/components/calendar/calendar-next.ts
@@ -21,7 +21,7 @@ export class ScCalendarNext {
   protected readonly class = computed(() =>
     cn(
       buttonVariants({ variant: this.variant(), size: this.size() }),
-      'absolute right-1',
+      'absolute end-1',
       this.classInput(),
     ),
   );

--- a/libs/ui/src/lib/components/calendar/calendar-previous.ts
+++ b/libs/ui/src/lib/components/calendar/calendar-previous.ts
@@ -21,7 +21,7 @@ export class ScCalendarPrevious {
   protected readonly class = computed(() =>
     cn(
       buttonVariants({ variant: this.variant(), size: this.size() }),
-      'absolute left-1',
+      'absolute start-1',
       this.classInput(),
     ),
   );

--- a/libs/ui/src/lib/components/combobox/combobox-clear.ts
+++ b/libs/ui/src/lib/components/combobox/combobox-clear.ts
@@ -19,7 +19,7 @@ export class ScComboboxClear {
 
   protected readonly class = computed(() =>
     cn(
-      'absolute right-7 flex size-4 items-center justify-center rounded-full opacity-50 hover:opacity-100 [&_svg]:size-3',
+      'absolute end-7 flex size-4 items-center justify-center rounded-full opacity-50 hover:opacity-100 [&_svg]:size-3',
       this.classInput(),
     ),
   );

--- a/libs/ui/src/lib/components/dialog/dialog-close.ts
+++ b/libs/ui/src/lib/components/dialog/dialog-close.ts
@@ -21,7 +21,7 @@ export class ScDialogClose {
   protected readonly class = computed(() =>
     cn(
       buttonVariants({ variant: this.variant(), size: this.size() }),
-      'absolute top-2 right-2',
+      'absolute top-2 end-2',
       this.classInput(),
     ),
   );

--- a/libs/ui/src/lib/components/native-select/native-select-icon.ts
+++ b/libs/ui/src/lib/components/native-select/native-select-icon.ts
@@ -12,7 +12,7 @@ export class ScNativeSelectIcon {
 
   protected readonly class = computed(() =>
     cn(
-      'text-muted-foreground top-1/2 right-2.5 size-4 -translate-y-1/2 pointer-events-none absolute select-none',
+      'text-muted-foreground top-1/2 end-2.5 size-4 -translate-y-1/2 pointer-events-none absolute select-none',
       this.classInput(),
     ),
   );

--- a/libs/ui/src/lib/components/navigation-menu/navigation-menu-content.ts
+++ b/libs/ui/src/lib/components/navigation-menu/navigation-menu-content.ts
@@ -27,7 +27,7 @@ export class ScNavigationMenuContent {
   protected readonly class = computed(() =>
     cn(
       'block',
-      'left-0 top-0 w-full md:absolute md:w-auto',
+      'start-0 top-0 w-full md:absolute md:w-auto',
       'bg-popover text-popover-foreground',
       'rounded-md border shadow-lg',
       'overflow-hidden',

--- a/libs/ui/src/lib/components/popover/popover-close.ts
+++ b/libs/ui/src/lib/components/popover/popover-close.ts
@@ -15,7 +15,7 @@ export class ScPopoverClose {
 
   protected readonly class = computed(() =>
     cn(
-      'absolute right-2 top-2 rounded-sm opacity-70 ring-offset-background transition-opacity',
+      'absolute end-2 top-2 rounded-sm opacity-70 ring-offset-background transition-opacity',
       'hover:opacity-100',
       'focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
       this.classInput(),

--- a/libs/ui/src/lib/components/scroll-area/scroll-area-scrollbar.ts
+++ b/libs/ui/src/lib/components/scroll-area/scroll-area-scrollbar.ts
@@ -184,8 +184,8 @@ export class ScScrollBar {
     cn(
       'absolute touch-none select-none transition-opacity',
       this.isVertical()
-        ? 'top-0 right-0 h-full w-2.5'
-        : 'bottom-0 left-0 w-full h-2.5',
+        ? 'top-0 end-0 h-full w-2.5'
+        : 'bottom-0 start-0 w-full h-2.5',
       this.dragging()
         ? '!opacity-100'
         : this.visible()

--- a/libs/ui/src/lib/components/select/select-item-indicator.ts
+++ b/libs/ui/src/lib/components/select/select-item-indicator.ts
@@ -12,7 +12,7 @@ export class ScSelectItemIndicator {
 
   protected readonly class = computed(() =>
     cn(
-      'pointer-events-none absolute right-2 flex size-4 items-center justify-center opacity-0 [[aria-selected=true]>&]:opacity-100',
+      'pointer-events-none absolute end-2 flex size-4 items-center justify-center opacity-0 [[aria-selected=true]>&]:opacity-100',
       this.classInput(),
     ),
   );

--- a/libs/ui/src/lib/components/sheet/sheet-close.ts
+++ b/libs/ui/src/lib/components/sheet/sheet-close.ts
@@ -20,7 +20,7 @@ export class ScSheetClose {
   protected readonly class = computed(() =>
     cn(
       buttonVariants({ variant: this.variant(), size: this.size() }),
-      'absolute top-3 right-3 z-10',
+      'absolute top-3 end-3 z-10',
       this.classInput(),
     ),
   );

--- a/libs/ui/src/lib/components/tabs/tab.ts
+++ b/libs/ui/src/lib/components/tabs/tab.ts
@@ -36,7 +36,7 @@ export class ScTab {
       // line variant underline/side indicator
       'after:bg-foreground after:absolute after:opacity-0 after:transition-opacity',
       'group-data-[orientation=horizontal]/tabs:after:inset-x-0 group-data-[orientation=horizontal]/tabs:after:bottom-[-5px] group-data-[orientation=horizontal]/tabs:after:h-0.5',
-      'group-data-[orientation=vertical]/tabs:after:inset-y-0 group-data-[orientation=vertical]/tabs:after:-right-1 group-data-[orientation=vertical]/tabs:after:w-0.5',
+      'group-data-[orientation=vertical]/tabs:after:inset-y-0 group-data-[orientation=vertical]/tabs:after:-end-1 group-data-[orientation=vertical]/tabs:after:w-0.5',
       'group-data-[variant=line]/tab-list:aria-selected:after:opacity-100',
       this.classInput(),
     ),

--- a/libs/ui/src/lib/components/toast/toast-close.ts
+++ b/libs/ui/src/lib/components/toast/toast-close.ts
@@ -18,7 +18,7 @@ export class ScToastClose {
 
   protected readonly class = computed(() =>
     cn(
-      'absolute right-1 top-1 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity',
+      'absolute end-1 top-1 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity',
       'hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-1 group-hover:opacity-100',
       'group-[.destructive]:text-red-800/50 group-[.destructive]:hover:text-red-800',
       'group-[.destructive]:focus:ring-red-400',


### PR DESCRIPTION
Converts **27 of the 71** physical `left-*`/`right-*` positioning utilities to `start-*`/`end-*` — the last mechanical piece of RTL support. The other 44 stay physical deliberately.

## Flipped (27)

Affordances whose edge is "the trailing one", not a physical side:

| Group | Components |
|---|---|
| Close buttons | dialog, sheet, popover, toast, spotlight, lightbox, tour-guide, native-dialog |
| Indicators & badges | select item indicator, avatar badge, dock badge, notification dot, vertical tab indicator, tour-guide step number |
| Navigation | calendar prev/next, lightbox prev/next |
| Alignment | navigation-menu content, data-table column toggle, scroll-area scrollbar, timeline dot, combobox clear, native-select icon |

## Left physical (44), in four groups

- **Centering** — `left-1/2` paired with `-translate-x-1/2`. The translate doesn't flip, so converting the inset alone would break the centring (tooltip, radio, resizable handle, toast-stack centre positions).
- **Explicit physical APIs** — toast-stack's `'top-left'`/`'bottom-right'` position names, and drawer/sheet/sidebar's `data-[side=…]` variants. There "left" means literally left, same call as in #1506.
- **Spatial widgets** — image cropper, image compare, image annotator, org-chart. Positions pair with physical resize cursors, or mirror a diagram that shouldn't flip.
- **Media progress overlays** — video/audio progress fills sit absolutely over a slider. They use `[style.width.%]` with no left math, but I did not verify the slider's own thumb positioning, and flipping one without the other would desync them. Flagging rather than guessing.

## Verification

All six logical inset forms compiled through the repo's Tailwind, including the negatives:

```css
.start-1  { inset-inline-start: calc(var(--spacing) * 1) }
.-end-1   { inset-inline-end:   calc(var(--spacing) * -1) }
.end-2\.5 { inset-inline-end:   calc(var(--spacing) * 2.5) }
```

27 flipped + 44 left = 71, and the residual grep matches the leave-list exactly with nothing unaccounted for. `nx lint` clean across `ui`, `ui-lab`, `carousel`, `code` (32 warnings, unchanged); `tsc --noEmit` exit 0; `validate-demo-code` 0 mismatches; 18/18 tests.

Nothing asserts computed classes, so this wants a pass with `dir="rtl"` — the close buttons and the calendar/lightbox navigation are the most visible.

## RTL after this

Logical properties, `space-x-reverse`, directional icons and positional insets are all done. What's left is judgment-dependent, not mechanical: the `breadcrumb-separator` chevron (the lib projects arbitrary content, so it belongs in the demos) and the two media progress overlays above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)