### PR TITLE
fix(dialog,sheet,drawer): use popover surface tokens; card spacing via --card-spacing

### DIFF
--- a/libs/ui/src/lib/components/card/card-body.ts
+++ b/libs/ui/src/lib/components/card/card-body.ts
@@ -11,6 +11,6 @@ export class ScCardBody {
   readonly classInput = input<string>('', { alias: 'class' });
 
   protected readonly class = computed(() =>
-    cn('px-4 group-data-[size=sm]/card:px-3', this.classInput()),
+    cn('px-(--card-spacing)', this.classInput()),
   );
 }

--- a/libs/ui/src/lib/components/card/card-footer.ts
+++ b/libs/ui/src/lib/components/card/card-footer.ts
@@ -13,7 +13,7 @@ export class ScCardFooter {
 
   protected readonly class = computed(() =>
     cn(
-      'bg-muted/50 rounded-b-xl border-t p-4 group-data-[size=sm]/card:p-3 flex items-center',
+      'bg-muted/50 rounded-b-xl border-t p-(--card-spacing) flex items-center',
       this.classInput(),
     ),
   );

--- a/libs/ui/src/lib/components/card/card-header.ts
+++ b/libs/ui/src/lib/components/card/card-header.ts
@@ -12,7 +12,7 @@ export class ScCardHeader {
 
   protected readonly class = computed(() =>
     cn(
-      'gap-1 rounded-t-xl px-4 group-data-[size=sm]/card:px-3 [.border-b]:pb-4 group-data-[size=sm]/card:[.border-b]:pb-3 group/card-header @container/card-header grid auto-rows-min items-start has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto]',
+      'gap-1 rounded-t-xl px-(--card-spacing) [.border-b]:pb-(--card-spacing) group/card-header @container/card-header grid auto-rows-min items-start has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto]',
       this.classInput(),
     ),
   );

--- a/libs/ui/src/lib/components/card/card.ts
+++ b/libs/ui/src/lib/components/card/card.ts
@@ -14,7 +14,7 @@ export class ScCard {
 
   protected readonly class = computed(() =>
     cn(
-      'ring-foreground/10 bg-card text-card-foreground gap-4 overflow-hidden rounded-xl py-4 text-sm ring-1 has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl group/card flex flex-col',
+      'ring-foreground/10 bg-card text-card-foreground gap-(--card-spacing) overflow-hidden rounded-xl py-(--card-spacing) text-sm ring-1 [--card-spacing:--spacing(4)] has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:[--card-spacing:--spacing(3)] data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl group/card flex flex-col',
       this.classInput(),
     ),
   );

--- a/libs/ui/src/lib/components/dialog/dialog.ts
+++ b/libs/ui/src/lib/components/dialog/dialog.ts
@@ -47,7 +47,7 @@ export class ScDialog {
 
   protected readonly class = computed(() =>
     cn(
-      'mx-auto relative bg-background ring-foreground/10 grid w-full max-w-[calc(100%-2rem)] gap-4 rounded-xl p-4 text-sm ring-1 duration-100 outline-none sm:max-w-sm',
+      'mx-auto relative bg-popover text-popover-foreground ring-foreground/10 grid w-full max-w-[calc(100%-2rem)] gap-4 rounded-xl p-4 text-sm ring-1 duration-100 outline-none sm:max-w-sm',
       'data-idle:opacity-0',
       'data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95',
       'data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',

--- a/libs/ui/src/lib/components/drawer/drawer.ts
+++ b/libs/ui/src/lib/components/drawer/drawer.ts
@@ -34,7 +34,7 @@ export class ScDrawer {
 
   protected readonly class = computed(() =>
     cn(
-      'bg-background flex h-auto flex-col text-sm fixed z-50 group/drawer',
+      'bg-popover text-popover-foreground flex h-auto flex-col text-sm fixed z-50 group/drawer',
       // Position and border based on direction
       'data-[direction=bottom]:inset-x-0 data-[direction=bottom]:bottom-0 data-[direction=bottom]:mt-24 data-[direction=bottom]:max-h-[80vh] data-[direction=bottom]:rounded-t-xl data-[direction=bottom]:border-t',
       'data-[direction=left]:inset-y-0 data-[direction=left]:left-0 data-[direction=left]:w-3/4 data-[direction=left]:rounded-r-xl data-[direction=left]:border-r',

--- a/libs/ui/src/lib/components/sheet/sheet.ts
+++ b/libs/ui/src/lib/components/sheet/sheet.ts
@@ -47,7 +47,7 @@ export class ScSheet {
 
   protected readonly class = computed(() =>
     cn(
-      'bg-background fixed z-50 flex flex-col gap-4 p-6 shadow-lg duration-200 ease-in-out transition',
+      'bg-popover text-popover-foreground fixed z-50 flex flex-col gap-4 p-6 shadow-lg duration-200 ease-in-out transition',
       // Position based on side
       'data-[side=bottom]:inset-x-0 data-[side=bottom]:bottom-0 data-[side=bottom]:h-auto data-[side=bottom]:border-t',
       'data-[side=left]:inset-y-0 data-[side=left]:left-0 data-[side=left]:h-full data-[side=left]:w-3/4 data-[side=left]:border-r data-[side=left]:sm:max-w-sm',


### PR DESCRIPTION
First component-parity batch: `input`, `select`, `dialog`, `card`, `alert`. Two findings, one a real dark-mode bug.

## 1. Overlay surfaces used the wrong token (bug)

`dialog`, `sheet` and `drawer` all used `bg-background` with no explicit foreground. Upstream's `.cn-dialog-content`, `.cn-sheet-content` and `.cn-drawer-content` all use `bg-popover text-popover-foreground`.

Invisible in light mode, wrong in dark:

| Token | Light | Dark |
|---|---|---|
| `--background` | `oklch(1 0 0)` | `oklch(0.145 0 0)` |
| `--popover` | `oklch(1 0 0)` | **`oklch(0.205 0 0)`** |

So in dark mode all three rendered **the same colour as the page behind them**, separated only by a `ring-foreground/10` hairline. `--popover` is lighter precisely so an overlay reads as elevated.

`text-popover-foreground` resolves to the same value as the inherited foreground in both themes today, so it changes nothing now — it keeps the pairing correct for custom themes that set one and not the other.

Our `ScBackdrop` already matches `.cn-dialog-overlay` exactly, and `select-popup` already used `bg-popover`, so those needed nothing.

## 2. Card spacing now driven by `--card-spacing`

Upstream sets one custom property on the root and has children read it. We hardcoded the value in each child and repeated the small-size override four times:

```
card         gap-4 py-4 data-[size=sm]:gap-3 data-[size=sm]:py-3
card-header  px-4 group-data-[size=sm]/card:px-3
             [.border-b]:pb-4 group-data-[size=sm]/card:[.border-b]:pb-3
card-body    px-4 group-data-[size=sm]/card:px-3
card-footer  p-4  group-data-[size=sm]/card:p-3
```

→ root declares `[--card-spacing:--spacing(4)]` and `data-[size=sm]:[--card-spacing:--spacing(3)]`; children just use `px-(--card-spacing)` / `p-(--card-spacing)`.

**Rendered values are unchanged** — `--spacing(4)` resolves to the same `calc(var(--spacing) * 4)` that `p-4` emits. It also restores a customisation hook: setting `[--card-spacing:…]` on one card now retunes its whole subtree, where before a consumer had to override the root *and* every child.

## Clean, no changes needed

- **`input`** — contains upstream's `.cn-input` set verbatim, plus our own additions
- **`alert`** — base (RTL-normalised `text-start`/`pe-18`), both variants, title, description and action all match
- **`select`** — `select-popup` already correct; the trigger architecture diverges enough that a rule-by-rule comparison isn't meaningful

## Verification

- All six `--card-spacing` utilities compiled through the repo's Tailwind, including `[--card-spacing:--spacing(4)]` → `--card-spacing: calc(var(--spacing) * 4)`
- **`tailwind-merge` handles the variable syntax**, so consumer overrides still win — checked `p-(--card-spacing)` + `p-6` → `p-6`, and the `px`/`gap`/`py`+`p-0` cases
- No `bg-background` remains on any overlay surface
- `card-title` keeps `group-data-[size=sm]/card:text-sm` (upstream has it too), so `group/card` is still required
- `nx lint ui` clean, 0 warnings; `tsc --noEmit` exit 0; `validate-demo-code` 0 mismatches; 18/18 tests

**Worth an eyeball in dark mode** — the dialog/sheet/drawer change is the visible one, and nothing in the suite asserts computed classes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)