### PR TITLE
fix(checkbox,switch,tabs): align with shadcn nova

### DIFF
--- a/libs/ui/src/lib/components/checkbox/checkbox-visual.ts
+++ b/libs/ui/src/lib/components/checkbox/checkbox-visual.ts
@@ -33,11 +33,10 @@ export class ScCheckboxVisual {
 
   protected readonly class = computed(() =>
     cn(
-      'pointer-events-none inline-flex size-4 shrink-0 items-center justify-center rounded-sm border border-primary transition-colors',
-      'data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground',
-      'data-[state=indeterminate]:bg-primary data-[state=indeterminate]:text-primary-foreground',
-      'ring-offset-background',
-      'peer-focus-visible:outline-none peer-focus-visible:ring-2 peer-focus-visible:ring-ring peer-focus-visible:ring-offset-2',
+      'pointer-events-none inline-flex size-4 shrink-0 items-center justify-center rounded-sm border border-input dark:bg-input/30 transition-colors',
+      'data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground data-[state=checked]:border-primary',
+      'data-[state=indeterminate]:bg-primary data-[state=indeterminate]:text-primary-foreground data-[state=indeterminate]:border-primary',
+      'peer-focus-visible:border-ring peer-focus-visible:ring-ring/50 peer-focus-visible:ring-3',
       'peer-disabled:cursor-not-allowed peer-disabled:opacity-50',
       this.classInput(),
     ),

--- a/libs/ui/src/lib/components/switch/switch-visual.ts
+++ b/libs/ui/src/lib/components/switch/switch-visual.ts
@@ -39,7 +39,7 @@ export class ScSwitchVisual {
     cn(
       'pointer-events-none block size-4 rounded-full bg-background ring-0 transition-transform',
       this.switchField.dataState() === 'checked'
-        ? 'translate-x-[calc(100%-2px)]'
+        ? 'translate-x-[calc(100%-2px)] rtl:-translate-x-[calc(100%-2px)]'
         : 'translate-x-0',
       this.switchField.dataState() === 'checked'
         ? 'dark:bg-primary-foreground'

--- a/libs/ui/src/lib/components/tabs/tab.ts
+++ b/libs/ui/src/lib/components/tabs/tab.ts
@@ -21,6 +21,7 @@ export class ScTab {
       'gap-1.5 rounded-md border border-transparent px-1.5 py-0.5 text-sm font-medium',
       'group-data-[variant=default]/tab-list:aria-selected:shadow-sm group-data-[variant=line]/tab-list:aria-selected:shadow-none',
       "[&_svg:not([class*='size-'])]:size-4",
+      'has-data-[icon=inline-end]:pe-1 has-data-[icon=inline-start]:ps-1',
       'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring',
       'text-foreground/60 hover:text-foreground dark:text-muted-foreground dark:hover:text-foreground',
       'relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center whitespace-nowrap transition-all',


### PR DESCRIPTION
Batch 2 of the component comparison: `accordion`, `tabs`, `table`, `checkbox`, `switch`.

**`accordion` and `table` matched upstream exactly** — untouched. Accordion's content uses Angular's `animate.enter`/`animate.leave` instead of upstream's `data-open:`/`data-closed:` classes, but the same keyframes and equivalent intent.

## checkbox — three deviations from `.cn-checkbox`

| | ours | upstream |
|---|---|---|
| Unchecked border | `border-primary` | `border-input` |
| Unchecked dark fill | *(none)* | `dark:bg-input/30` |
| Focus ring | `ring-2` + `ring-offset-2` + `ring-offset-background` | `border-ring` + `ring-ring/50` + `ring-3` |

The border one is the visible bug: unchecked checkboxes were drawn with an **accent-coloured** border rather than the neutral input border. The focus ring was the pre-v4 offset style — `button`, `input` and `switch` in this repo already use the current one, so checkbox was the odd one out.

Also now sets `border-primary` when checked/indeterminate (upstream's `data-checked:border-primary`) so the border tracks the fill.

## switch — thumb slid the wrong way in RTL

The thumb's `translate-x-[calc(100%-2px)]` had no `rtl:` counterpart. `translate-x` has no logical form, so in RTL the thumb moved *away* from the track. Now paired with `rtl:-translate-x-[calc(100%-2px)]`.

**The earlier RTL passes missed this** because `translate-x` wasn't in their sweep — it's one of the four non-rename rules in upstream's mapping table, not a physical→logical swap.

## tabs

`tab` was missing upstream's `has-data-[icon=inline-*]` padding; added, RTL-normalised to `pe-1`/`ps-1`.

## Deliberately not done

- **`aria-invalid` styling.** Upstream's checkbox and switch both carry invalid ring/border rules, but neither `checkbox.ts` nor `switch.ts` binds `aria-invalid`, so `peer-aria-invalid:` would never match. Adding it means wiring the binding as well — a behaviour change, and arguably an a11y fix worth its own PR.
- **`data-[size=sm]` on switch.** Upstream has it; we hardcode the default size. Feature gap, not a divergence.

## Verification

Every added class compiled through the repo's Tailwind, including the negative arbitrary value: `rtl:-translate-x-[calc(100%-2px)]` → `--tw-translate-x: calc(calc(100% - 2px) * -1)`. Confirmed the `peer` chain is valid — `ScCheckboxField` projects the input *before* the visual span, which is what the existing `peer-focus-visible:` rules already depend on.

`nx lint ui` clean, 0 warnings; `tsc --noEmit` exit 0; `validate-demo-code` 0 mismatches; 18/18 tests. Nothing asserts computed classes, so the checkbox border/focus change and the switch in `dir="rtl"` want an eyeball.

## One correction

I initially reported the switch thumb as having no dark-mode colours. It does — `dark:bg-primary-foreground` / `dark:bg-foreground` in its ternary. I'd read a truncated grep; reading the full file corrected it. No change was made on that basis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)