### PR TITLE
fix(tooltip,menu,kbd): align with shadcn nova

### DIFF
--- a/libs/ui/src/lib/components/kbd/kbd-group.ts
+++ b/libs/ui/src/lib/components/kbd/kbd-group.ts
@@ -4,6 +4,7 @@ import { cn } from '../../utils';
 @Directive({
   selector: 'kbd[scKbdGroup]',
   host: {
+    'data-slot': 'kbd-group',
     '[class]': 'class()',
   },
 })

--- a/libs/ui/src/lib/components/kbd/kbd.ts
+++ b/libs/ui/src/lib/components/kbd/kbd.ts
@@ -4,6 +4,7 @@ import { cn } from '../../utils';
 @Directive({
   selector: 'kbd[scKbd]',
   host: {
+    'data-slot': 'kbd',
     '[class]': 'class()',
   },
 })

--- a/libs/ui/src/lib/components/menu/menu-item.ts
+++ b/libs/ui/src/lib/components/menu/menu-item.ts
@@ -66,6 +66,7 @@ export class ScMenuItem {
   protected readonly class = computed(() =>
     cn(
       'data-[active=true]:bg-accent data-[active=true]:text-accent-foreground gap-1.5 rounded-md px-1.5 py-1 text-sm relative flex cursor-default items-center outline-hidden select-none focus-visible:outline-2 focus-visible:outline-ring',
+      "[&_svg:not([class*='size-'])]:size-4",
       this.classInput(),
     ),
   );

--- a/libs/ui/src/lib/components/tooltip/tooltip.ts
+++ b/libs/ui/src/lib/components/tooltip/tooltip.ts
@@ -28,7 +28,7 @@ type ScTooltipSide = 'top' | 'right' | 'bottom' | 'left';
     {{ data.content }}
     <span
       [attr.data-side]="side()"
-      class="bg-primary absolute z-50 size-2.5 rotate-45 rounded-[2px] data-[side=bottom]:-top-[5px] data-[side=bottom]:left-1/2 data-[side=bottom]:-translate-x-1/2 data-[side=left]:top-1/2 data-[side=left]:-right-[5px] data-[side=left]:-translate-y-1/2 data-[side=right]:top-1/2 data-[side=right]:-left-[5px] data-[side=right]:-translate-y-1/2 data-[side=top]:-bottom-[5px] data-[side=top]:left-1/2 data-[side=top]:-translate-x-1/2"
+      class="bg-foreground absolute z-50 size-2.5 rotate-45 rounded-[2px] data-[side=bottom]:-top-[5px] data-[side=bottom]:left-1/2 data-[side=bottom]:-translate-x-1/2 data-[side=left]:top-1/2 data-[side=left]:-right-[5px] data-[side=left]:-translate-y-1/2 data-[side=right]:top-1/2 data-[side=right]:-left-[5px] data-[side=right]:-translate-y-1/2 data-[side=top]:-bottom-[5px] data-[side=top]:left-1/2 data-[side=top]:-translate-x-1/2"
     ></span>
   `,
   host: {
@@ -54,7 +54,9 @@ export class ScTooltip {
 
   protected readonly hostClass = computed(() =>
     cn(
-      'bg-primary text-primary-foreground z-50 rounded-md px-3 py-1.5 text-xs w-fit max-w-xs',
+      'bg-foreground text-background z-50 rounded-md px-3 py-1.5 text-xs w-fit max-w-xs',
+      'inline-flex items-center gap-1.5',
+      'has-data-[slot=kbd]:pe-1.5 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm',
       'data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95',
       'data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
       'data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',


### PR DESCRIPTION
Batch 3: `popover`, `tooltip`, `menu`, `command`, `combobox`.

**`popover` matches upstream exactly**, and `command` / `combobox` already use the popover surface tokens correctly — untouched. (Upstream's `-logical` companion classes for `data-[side=inline-start/end]` don't apply: we only ever emit physical side values.)

## tooltip used the wrong surface token

`bg-primary text-primary-foreground` is shadcn **v3**'s tooltip. v4 uses `bg-foreground text-background`.

| | Light | Dark |
|---|---|---|
| ours: `--primary` | `oklch(0.205 0 0)` | `oklch(0.922 0 0)` |
| upstream: `--foreground` | `oklch(0.145 0 0)` | `oklch(0.985 0 0)` |

Nearly identical in the default neutral theme — but `--primary` is the token consumers are most likely to rebrand, and a tooltip is meant to be a neutral inverted surface, not a brand-coloured one. Set `--primary` to your brand blue today and every tooltip turns blue. The inline arrow used `bg-primary` for the same reason and moves with it.

Also missing: `inline-flex items-center gap-1.5` (multi-child tooltip content didn't align or space) and upstream's kbd handling.

## The kbd rules would have been dead CSS

`ScKbd` **didn't set `data-slot` at all**, so adding `has-data-[slot=kbd]:` / `**:data-[slot=kbd]:` to the tooltip alone would have shipped rules that can never match — the same failure mode as the button `[a]:` variant.

`ScKbd` and `ScKbdGroup` now set `data-slot="kbd"` / `"kbd-group"`, matching upstream and the repo's own data-slot pattern. Verified nothing else in `libs` keys off those values, so this activates only the new tooltip rules.

## menu

`menu-item` was missing upstream's icon normalisation `[&_svg:not([class*='size-'])]:size-4`. `menu` content itself already uses `bg-popover text-popover-foreground` correctly.

## Noted, not addressed

- Our menu content has **no enter/exit animation**, where upstream animates in and out with slide-ins per side.
- No destructive menu-item variant, and no `data-inset` support.
- **Many other components lack `data-slot`** (alert, badge, button, card, dialog, drawer, command, combobox and ~15 more). That's a wider cleanup than one batch, but it means any upstream rule keyed on a slot is silently inert for those components — worth a dedicated pass.

## Verification

`has-data-[slot=kbd]:pe-1.5` and `**:data-[slot=kbd]:rounded-sm` compiled through the repo's Tailwind to confirm the selectors resolve (`:has([data-slot="kbd"])` and `:is(… *)[data-slot="kbd"]`). `nx lint ui` clean, 0 warnings; `tsc --noEmit` exit 0; `validate-demo-code` 0 mismatches; 18/18 tests.

The tooltip colour change is visible on every tooltip — worth a look, and nothing in the suite asserts computed classes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)