### PR TITLE
fix: wire up the data-slot values our own rules depend on

### DIFF
--- a/libs/ui/src/lib/components/combobox/combobox-dialog.ts
+++ b/libs/ui/src/lib/components/combobox/combobox-dialog.ts
@@ -16,6 +16,9 @@ import { ScCombobox } from './combobox';
 @Directive({
   selector: 'dialog[scComboboxDialog]',
   host: {
+    // Named for upstream's slot so input-group's
+    // in-data-[slot=combobox-content] rules apply.
+    'data-slot': 'combobox-content',
     '[class]': 'class()',
   },
 })

--- a/libs/ui/src/lib/components/item/item.ts
+++ b/libs/ui/src/lib/components/item/item.ts
@@ -14,7 +14,7 @@ export const itemVariants = cva(
       size: {
         default: 'gap-2.5 px-3 py-2.5',
         sm: 'gap-2.5 px-3 py-2.5',
-        xs: 'gap-2 px-2.5 py-2 in-data-[slot=dropdown-menu-content]:p-0',
+        xs: 'gap-2 px-2.5 py-2 in-data-[slot=menu]:p-0',
       },
     },
     defaultVariants: {

--- a/libs/ui/src/lib/components/tooltip/tooltip.ts
+++ b/libs/ui/src/lib/components/tooltip/tooltip.ts
@@ -32,6 +32,7 @@ type ScTooltipSide = 'top' | 'right' | 'bottom' | 'left';
     ></span>
   `,
   host: {
+    'data-slot': 'tooltip-content',
     role: 'tooltip',
     'aria-live': 'polite',
     'aria-atomic': 'true',


### PR DESCRIPTION
The kbd fix in #1512 showed a failure mode worth auditing: a rule can reference a `data-slot` that **nothing sets**, and it's dead CSS no test or typecheck catches. This compares every slot our rules reference against every slot we actually set.

## Three were dead with a component to hang off

**`tooltip-content`** — `kbd` restyles itself inside a tooltip (`in-data-[slot=tooltip-content]:bg-background/20`, `:text-background`, plus a dark variant), but the tooltip host set no slot. This is the **other half of #1512**: that PR taught the tooltip to pad and isolate a kbd; this lets the kbd restyle itself for the dark surface. Neither worked alone.

**`combobox-content`** — `input-group` suppresses its own border and focus ring inside combobox content, but `ScComboboxDialog` set no slot. So an input-group inside a combobox drew a competing ring.

**`dropdown-menu-content`** — `item`'s `xs` size drops padding inside a menu. The rule was copied from upstream and still used upstream's name; our equivalent surface is `ScMenu`, which **already** sets `data-slot="menu"`. Pointed the rule there rather than adding an attribute.

## Two stay dead, deliberately

- **`checkbox-group`** (referenced by `field-group`, `fieldset`) — we have no checkbox-group component. Upstream does. Feature gap, not a wiring bug.
- **`select-input-group`** (referenced by `button-group`) — no such component exists here at all. The rule's intent needs recovering from upstream before it can be wired or removed; guessing would be worse than leaving it inert.

## Scope correction

I told you this was ~20 components. It's **~280 directives** across `libs` that set no `data-slot` — I'd only checked one file per directory. Adding all of them is a much larger change with a public API surface (consumers can target `[data-slot=…]`), and it isn't needed to fix dead CSS. So this PR stays limited to slots something already references.

The broader question — whether to mirror upstream and set `data-slot` universally — is worth deciding separately.

## Method note

My first pass reported 6 dead slots, including `accordion-trigger-icon`. That was a false positive: the accordion sets it as a **template attribute**, and my extraction only matched the `'data-slot': '…'` host-binding form. Re-ran collecting both forms before acting.

## Verification

Re-ran the audit after the changes — only the two intentional ones remain. `nx lint ui` clean, 0 warnings; `tsc --noEmit` exit 0; `validate-demo-code` 0 mismatches; 18/18 tests.

The visible effect is a kbd inside a tooltip and an input-group inside a combobox; both want an eyeball since nothing asserts computed classes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)