### PR TITLE
fix(radio,label): align with shadcn nova

### DIFF
--- a/libs/ui/src/lib/components/combobox/combobox-dialog.ts
+++ b/libs/ui/src/lib/components/combobox/combobox-dialog.ts
@@ -16,6 +16,9 @@ import { ScCombobox } from './combobox';
 @Directive({
   selector: 'dialog[scComboboxDialog]',
   host: {
+    // Named for upstream's slot so input-group's
+    // in-data-[slot=combobox-content] rules apply.
+    'data-slot': 'combobox-content',
     '[class]': 'class()',
   },
 })

--- a/libs/ui/src/lib/components/item/item.ts
+++ b/libs/ui/src/lib/components/item/item.ts
@@ -14,7 +14,7 @@ export const itemVariants = cva(
       size: {
         default: 'gap-2.5 px-3 py-2.5',
         sm: 'gap-2.5 px-3 py-2.5',
-        xs: 'gap-2 px-2.5 py-2 in-data-[slot=dropdown-menu-content]:p-0',
+        xs: 'gap-2 px-2.5 py-2 in-data-[slot=menu]:p-0',
       },
     },
     defaultVariants: {

--- a/libs/ui/src/lib/components/label/label.ts
+++ b/libs/ui/src/lib/components/label/label.ts
@@ -24,7 +24,7 @@ export class ScLabel {
 
   protected readonly class = computed(() =>
     cn(
-      'has-data-checked:bg-primary/5 has-data-checked:border-primary dark:has-data-checked:bg-primary/10 gap-2 group-data-[disabled=true]/field:opacity-50 has-[>[data-slot=field]]:rounded-lg has-[>[data-slot=field]]:border *:data-[slot=field]:p-2.5 group/label peer/label flex w-fit leading-snug',
+      'has-data-checked:bg-primary/5 has-data-checked:border-primary dark:has-data-checked:bg-primary/10 gap-2 group-data-[disabled=true]/field:opacity-50 peer-disabled:opacity-50 has-[>[data-slot=field]]:rounded-lg has-[>[data-slot=field]]:border *:data-[slot=field]:p-2.5 group/label peer/label flex w-fit leading-snug',
       'has-[>[data-slot=field]]:w-full has-[>[data-slot=field]]:flex-col',
       this.classInput(),
     ),

--- a/libs/ui/src/lib/components/radio-group/radio.ts
+++ b/libs/ui/src/lib/components/radio-group/radio.ts
@@ -54,9 +54,11 @@ export class ScRadio {
     cn(
       'relative',
       'appearance-none',
-      'aspect-square h-4 w-4 rounded-full border border-primary text-primary shadow focus:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
+      'aspect-square h-4 w-4 rounded-full border border-input dark:bg-input/30 transition-colors disabled:cursor-not-allowed disabled:opacity-50',
+      'checked:bg-primary checked:border-primary checked:text-primary-foreground',
+      'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-3',
       "[&::before]:content-['']",
-      '[&::before]:absolute [&::before]:top-1/2 [&::before]:left-1/2 [&::before]:-translate-x-1/2 [&::before]:-translate-y-1/2 [&::before]:size-2.5 [&::before]:rounded-full [&::before]:bg-primary [&::before]:opacity-0 [&::before]:transform [&::before]:scale-0 [&::before]:transition-all [&::before]:duration-200',
+      '[&::before]:absolute [&::before]:top-1/2 [&::before]:left-1/2 [&::before]:-translate-x-1/2 [&::before]:-translate-y-1/2 [&::before]:size-2 [&::before]:rounded-full [&::before]:bg-primary-foreground [&::before]:opacity-0 [&::before]:transform [&::before]:scale-0 [&::before]:transition-all [&::before]:duration-200',
       'checked:[&::before]:opacity-100 checked:[&::before]:scale-100',
       this.classInput(),
     ),

--- a/libs/ui/src/lib/components/tooltip/tooltip.ts
+++ b/libs/ui/src/lib/components/tooltip/tooltip.ts
@@ -32,6 +32,7 @@ type ScTooltipSide = 'top' | 'right' | 'bottom' | 'left';
     ></span>
   `,
   host: {
+    'data-slot': 'tooltip-content',
     role: 'tooltip',
     'aria-live': 'polite',
     'aria-atomic': 'true',


### PR DESCRIPTION
Batch 5: `radio-group`, `field`, `label`, `textarea`, `native-select`.

**Stacked on #1513** — review that first; this targets `fix/data-slot-audit` as its base.

**`textarea` and `native-select` contain upstream's rule sets verbatim** (RTL-normalised) and are untouched, as is `radio-group`'s own `grid gap-2` and `native-select-icon`.

## radio — three deviations

Same accent-border bug checkbox had in #1511, plus an older focus ring and a different checked appearance:

| | ours | upstream |
|---|---|---|
| Unselected border | `border-primary` | `border-input` |
| Unselected dark fill | *(none)* | `dark:bg-input/30` |
| Focus ring | `ring-1` + `ring-ring` | `border-ring` + `ring-ring/50` + `ring-3` |
| Selected | transparent control, `bg-primary` dot | `bg-primary` control, `primary-foreground` dot |

The focus ring was **two generations behind** — `ring-1` where button, input, switch and now checkbox all use `ring-3` with `ring-ring/50`.

**The selected-state change is the most visible in this whole run:** a checked radio goes from an outlined circle with a coloured dot to a filled circle with a light dot. The `::before` dot changes colour and drops `size-2.5` → `size-2` to match `cn-radio-group-indicator-icon`. Worth looking at before merging if you'd rather keep the current look.

## label

Missing upstream's `peer-disabled:opacity-50`. Our label already dims via `group-data-[disabled=true]/field`, which covers labels inside a field — but not a label sitting as a peer of a disabled control.

## Not addressed

`radio` has no `aria-invalid` binding, so upstream's invalid ring/border rules have nothing to attach to. Same gap recorded for checkbox and switch in #1511 — that's now **three** form controls needing the binding, which makes it worth its own PR.

## Verification

`nx lint ui` clean, 0 warnings; `tsc --noEmit` exit 0; `validate-demo-code` 0 mismatches; 18/18 tests. Nothing asserts computed classes, so the radio change needs an eyeball in both themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)