### PR TITLE
feat(checkbox,switch): report invalid state via aria-invalid

### DIFF
--- a/apps/showcase/src/app/form-control-invalid.spec.ts
+++ b/apps/showcase/src/app/form-control-invalid.spec.ts
@@ -1,0 +1,93 @@
+import { Component, Type, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { ScCheckbox, ScSwitch } from '@semantic-components/ui';
+
+interface InvalidHost {
+  readonly invalid: ReturnType<typeof signal<boolean>>;
+  readonly touched: ReturnType<typeof signal<boolean>>;
+}
+
+@Component({
+  imports: [ScCheckbox],
+  template: `
+    <input
+      type="checkbox"
+      scCheckbox
+      [invalid]="invalid()"
+      [touched]="touched()"
+    />
+  `,
+})
+class CheckboxHost implements InvalidHost {
+  readonly invalid = signal(false);
+  readonly touched = signal(false);
+}
+
+@Component({
+  imports: [ScSwitch],
+  template: `
+    <input
+      type="checkbox"
+      scSwitch
+      [invalid]="invalid()"
+      [touched]="touched()"
+    />
+  `,
+})
+class SwitchHost implements InvalidHost {
+  readonly invalid = signal(false);
+  readonly touched = signal(false);
+}
+
+function mount(type: Type<InvalidHost>) {
+  TestBed.configureTestingModule({});
+  const fixture = TestBed.createComponent(type);
+  fixture.detectChanges();
+  return fixture;
+}
+
+function ariaInvalid(fixture: ReturnType<typeof mount>): string | null {
+  const input = (fixture.nativeElement as HTMLElement).querySelector('input');
+  return input!.getAttribute('aria-invalid');
+}
+
+describe('aria-invalid on form controls', () => {
+  const cases: [string, Type<InvalidHost>][] = [
+    ['checkbox', CheckboxHost],
+    ['switch', SwitchHost],
+  ];
+
+  for (const [name, type] of cases) {
+    describe(name, () => {
+      it('is absent by default', () => {
+        expect(ariaInvalid(mount(type))).toBeNull();
+      });
+
+      it('stays absent while invalid but untouched', () => {
+        const fixture = mount(type);
+        fixture.componentInstance.invalid.set(true);
+        fixture.detectChanges();
+
+        // Matches ScInput: a pristine control should not report as invalid.
+        expect(ariaInvalid(fixture)).toBeNull();
+      });
+
+      it('is set once invalid and touched', () => {
+        const fixture = mount(type);
+        fixture.componentInstance.invalid.set(true);
+        fixture.componentInstance.touched.set(true);
+        fixture.detectChanges();
+
+        expect(ariaInvalid(fixture)).toBe('true');
+      });
+
+      it('stays absent when touched but valid', () => {
+        const fixture = mount(type);
+        fixture.componentInstance.touched.set(true);
+        fixture.detectChanges();
+
+        expect(ariaInvalid(fixture)).toBeNull();
+      });
+    });
+  }
+});

--- a/libs/ui/src/lib/components/checkbox/checkbox-visual.ts
+++ b/libs/ui/src/lib/components/checkbox/checkbox-visual.ts
@@ -37,6 +37,8 @@ export class ScCheckboxVisual {
       'data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground data-[state=checked]:border-primary',
       'data-[state=indeterminate]:bg-primary data-[state=indeterminate]:text-primary-foreground data-[state=indeterminate]:border-primary',
       'peer-focus-visible:border-ring peer-focus-visible:ring-ring/50 peer-focus-visible:ring-3',
+      'peer-aria-invalid:border-destructive peer-aria-invalid:ring-destructive/20 peer-aria-invalid:ring-3',
+      'dark:peer-aria-invalid:border-destructive/50 dark:peer-aria-invalid:ring-destructive/40',
       'peer-disabled:cursor-not-allowed peer-disabled:opacity-50',
       this.classInput(),
     ),

--- a/libs/ui/src/lib/components/checkbox/checkbox.ts
+++ b/libs/ui/src/lib/components/checkbox/checkbox.ts
@@ -22,6 +22,7 @@ export const SC_CHECKBOX = 'SC_CHECKBOX';
     'data-slot': 'checkbox',
     '[id]': 'id()',
     '[attr.aria-describedby]': 'ariaDescribedBy()',
+    '[attr.aria-invalid]': 'ariaInvalid()',
     '[class]': 'class()',
     '[checked]': 'checked()',
     '(change)': 'onInputChange($event)',
@@ -52,6 +53,15 @@ export class ScCheckbox implements FormCheckboxControl {
       this.ariaDescribedByInput() ||
       this.field?.descriptionIds().join(' ') ||
       null,
+  );
+
+  // Bound automatically by the Field directive (FormUiControl contract).
+  readonly invalid = input<boolean>(false);
+  readonly touched = input<boolean>(false);
+
+  // Matches ScInput: do not surface invalid until the control is touched.
+  protected readonly ariaInvalid = computed(
+    () => (this.touched() && this.invalid()) || null,
   );
 
   // Expose disabled state as a signal

--- a/libs/ui/src/lib/components/switch/switch-visual.ts
+++ b/libs/ui/src/lib/components/switch/switch-visual.ts
@@ -30,6 +30,8 @@ export class ScSwitchVisual {
       'pointer-events-none inline-flex h-[18.4px] w-[32px] shrink-0 items-center rounded-full border border-transparent transition-all',
       'data-[state=checked]:bg-primary data-[state=unchecked]:bg-input dark:data-[state=unchecked]:bg-input/80',
       'peer-focus-visible:border-ring peer-focus-visible:ring-3 peer-focus-visible:ring-ring/50',
+      'peer-aria-invalid:border-destructive peer-aria-invalid:ring-destructive/20 peer-aria-invalid:ring-3',
+      'dark:peer-aria-invalid:border-destructive/50 dark:peer-aria-invalid:ring-destructive/40',
       'peer-disabled:cursor-not-allowed peer-disabled:opacity-50',
       this.classInput(),
     ),

--- a/libs/ui/src/lib/components/switch/switch.ts
+++ b/libs/ui/src/lib/components/switch/switch.ts
@@ -23,6 +23,7 @@ export const SC_SWITCH = 'SC_SWITCH';
     role: 'switch',
     '[id]': 'id()',
     '[attr.aria-describedby]': 'ariaDescribedBy()',
+    '[attr.aria-invalid]': 'ariaInvalid()',
     '[class]': 'class()',
     '[checked]': 'checked()',
     '(change)': 'onInputChange($event)',
@@ -50,6 +51,15 @@ export class ScSwitch implements FormCheckboxControl {
       this.ariaDescribedByInput() ||
       this.field?.descriptionIds().join(' ') ||
       null,
+  );
+
+  // Bound automatically by the Field directive (FormUiControl contract).
+  readonly invalid = input<boolean>(false);
+  readonly touched = input<boolean>(false);
+
+  // Matches ScInput: do not surface invalid until the control is touched.
+  protected readonly ariaInvalid = computed(
+    () => (this.touched() && this.invalid()) || null,
   );
 
   constructor() {


### PR DESCRIPTION
Upstream styles checkbox and switch for `aria-invalid`, but **neither control set the attribute** — so an invalid checkbox was neither announced to assistive technology nor shown as invalid. Recorded as a gap in #1511 and #1514; this closes it.

## Signal Forms already provides this

`FormUiControl` declares `invalid` and `touched` as **optional inputs the `Field` directive binds automatically**:

```ts
readonly invalid?: InputSignal<boolean> | InputSignalWithTransform<boolean, unknown>;
readonly touched?: InputSignal<boolean> | InputSignalWithTransform<boolean, unknown>;
```

So the controls only need to accept them.

**I got this wrong first.** I started by injecting `FormField` and reading `state().invalid()`, copying `ScInput`. The compiler rejected it — `FormCheckboxControl` types `invalid` as an `InputSignal`, because the contract is **push, not pull**. The final version has no `FormField` injection and is smaller for it.

`aria-invalid` is gated on `touched`, matching `ScInput`, so a pristine form doesn't render as invalid before the user has touched anything.

The visuals gain the matching destructive border and ring, which resolve to `:is(:where(.peer)[aria-invalid="true"] ~ *)` — verified against our `aria-invalid="true"` binding.

## Radio excluded, deliberately

`ScRadio` and `ScRadioGroup` have **no Signal Forms integration at all** — no `FormField`, no value binding, nothing implementing a control contract. There is no invalid state to read. Wiring that is an architectural change, not a style fix, and worth its own decision.

## Tests

Adds **8 tests** across both controls:

- absent by default
- absent while invalid but untouched (the touched gate)
- set once invalid and touched
- absent when touched but valid

Verified they're meaningful rather than tautological: the suite **exits 1 against the previous implementation** and 0 with the fix.

One thing the tests caught about themselves: the first version mutated plain properties on the host and called `detectChanges()`, which never re-rendered — OnPush is the default in v22, so the host was never marked dirty. The hosts use signals now. Worth knowing for future specs in this repo.

## Verification

26/26 tests pass (18 existing + 8 new). `nx lint` across `ui` and `showcase` — 7 warnings before and after, compared against a `git stash` baseline. `tsc --noEmit` exit 0; `validate-demo-code` 0 mismatches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)