### PR TITLE
fix(checkbox,switch): accept disabled as an input

### DIFF
--- a/apps/showcase/src/app/form-control-invalid.spec.ts
+++ b/apps/showcase/src/app/form-control-invalid.spec.ts
@@ -1,6 +1,11 @@
 import { Component, Type, signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { ScCheckbox, ScSwitch } from '@semantic-components/ui';
+import {
+  ScCheckbox,
+  ScCheckboxField,
+  ScSwitch,
+  ScSwitchField,
+} from '@semantic-components/ui';
 
 interface InvalidHost {
   readonly invalid: ReturnType<typeof signal<boolean>>;
@@ -87,6 +92,92 @@ describe('aria-invalid on form controls', () => {
         fixture.detectChanges();
 
         expect(ariaInvalid(fixture)).toBeNull();
+      });
+    });
+  }
+});
+
+@Component({
+  imports: [ScCheckbox, ScCheckboxField],
+  template: `
+    <div scCheckboxField>
+      <input type="checkbox" scCheckbox [disabled]="disabled()" />
+    </div>
+  `,
+})
+class CheckboxDisabledHost {
+  readonly disabled = signal(false);
+}
+
+@Component({
+  imports: [ScSwitch, ScSwitchField],
+  template: `
+    <div scSwitchField>
+      <input type="checkbox" scSwitch [disabled]="disabled()" />
+    </div>
+  `,
+})
+class SwitchDisabledHost {
+  readonly disabled = signal(false);
+}
+
+interface DisabledHost {
+  readonly disabled: ReturnType<typeof signal<boolean>>;
+}
+
+function mountDisabled(type: Type<DisabledHost>) {
+  TestBed.configureTestingModule({});
+  const fixture = TestBed.createComponent(type);
+  fixture.detectChanges();
+  return fixture;
+}
+
+describe('disabled on form controls', () => {
+  const cases: [string, Type<DisabledHost>][] = [
+    ['checkbox', CheckboxDisabledHost],
+    ['switch', SwitchDisabledHost],
+  ];
+
+  function fieldDisabled(fixture: ReturnType<typeof mountDisabled>) {
+    const field = (fixture.nativeElement as HTMLElement).querySelector('div')!;
+    return field.getAttribute('data-disabled');
+  }
+
+  for (const [name, type] of cases) {
+    describe(name, () => {
+      it('leaves the field enabled by default', () => {
+        expect(fieldDisabled(mountDisabled(type))).toBeNull();
+      });
+
+      // The old implementation read nativeElement.disabled in a non-reactive
+      // effect, so the field never picked the state up at all.
+      it('marks the field disabled when the control is disabled', () => {
+        const fixture = mountDisabled(type);
+        fixture.componentInstance.disabled.set(true);
+        fixture.detectChanges();
+
+        expect(fieldDisabled(fixture)).toBe('');
+      });
+
+      it('tracks a runtime toggle back to enabled', () => {
+        const fixture = mountDisabled(type);
+        fixture.componentInstance.disabled.set(true);
+        fixture.detectChanges();
+        fixture.componentInstance.disabled.set(false);
+        fixture.detectChanges();
+
+        expect(fieldDisabled(fixture)).toBeNull();
+      });
+
+      it('still disables the native input', () => {
+        const fixture = mountDisabled(type);
+        fixture.componentInstance.disabled.set(true);
+        fixture.detectChanges();
+
+        const input = (fixture.nativeElement as HTMLElement).querySelector(
+          'input',
+        )!;
+        expect(input.disabled).toBe(true);
       });
     });
   }

--- a/libs/ui/src/lib/components/checkbox/checkbox.ts
+++ b/libs/ui/src/lib/components/checkbox/checkbox.ts
@@ -2,12 +2,12 @@ import { _IdGenerator } from '@angular/cdk/a11y';
 import {
   Directive,
   ElementRef,
+  booleanAttribute,
   computed,
   effect,
   inject,
   input,
   model,
-  signal,
 } from '@angular/core';
 import type { FormCheckboxControl } from '@angular/forms/signals';
 import { cn } from '../../utils';
@@ -23,6 +23,7 @@ export const SC_CHECKBOX = 'SC_CHECKBOX';
     '[id]': 'id()',
     '[attr.aria-describedby]': 'ariaDescribedBy()',
     '[attr.aria-invalid]': 'ariaInvalid()',
+    '[attr.disabled]': 'disabled() || null',
     '[class]': 'class()',
     '[checked]': 'checked()',
     '(change)': 'onInputChange($event)',
@@ -64,25 +65,24 @@ export class ScCheckbox implements FormCheckboxControl {
     () => (this.touched() && this.invalid()) || null,
   );
 
-  // Expose disabled state as a signal
-  readonly disabledSignal = signal(false);
+  // Part of the FormUiControl contract, so the Field directive binds a
+  // disabled field straight to it.
+  readonly disabled = input<boolean, unknown>(false, {
+    transform: booleanAttribute,
+  });
+
+  // Kept for ScCheckboxField, which derives its data-disabled from this.
+  readonly disabledSignal = computed(() => this.disabled());
 
   constructor() {
     // Sync indeterminate input to native property
     effect(() => {
       this.elementRef.nativeElement.indeterminate = this.indeterminate();
     });
-
-    // Track disabled state
-    effect(() => {
-      this.disabledSignal.set(this.elementRef.nativeElement.disabled);
-    });
   }
 
   protected onInputChange(event: Event): void {
-    const input = event.target as HTMLInputElement;
-    this.checked.set(input.checked);
-    this.disabledSignal.set(input.disabled);
+    this.checked.set((event.target as HTMLInputElement).checked);
   }
 
   protected readonly class = computed(() =>

--- a/libs/ui/src/lib/components/switch/switch.ts
+++ b/libs/ui/src/lib/components/switch/switch.ts
@@ -1,13 +1,11 @@
 import { _IdGenerator } from '@angular/cdk/a11y';
 import {
   Directive,
-  ElementRef,
+  booleanAttribute,
   computed,
-  effect,
   inject,
   input,
   model,
-  signal,
 } from '@angular/core';
 import type { FormCheckboxControl } from '@angular/forms/signals';
 import { cn } from '../../utils';
@@ -24,6 +22,7 @@ export const SC_SWITCH = 'SC_SWITCH';
     '[id]': 'id()',
     '[attr.aria-describedby]': 'ariaDescribedBy()',
     '[attr.aria-invalid]': 'ariaInvalid()',
+    '[attr.disabled]': 'disabled() || null',
     '[class]': 'class()',
     '[checked]': 'checked()',
     '(change)': 'onInputChange($event)',
@@ -31,7 +30,6 @@ export const SC_SWITCH = 'SC_SWITCH';
   exportAs: SC_SWITCH,
 })
 export class ScSwitch implements FormCheckboxControl {
-  private readonly elementRef = inject(ElementRef<HTMLInputElement>);
   private readonly switchField = inject(SC_SWITCH_FIELD, { optional: true });
   protected readonly field = inject(SC_FIELD, { optional: true });
   private readonly fallbackId = inject(_IdGenerator).getId('sc-switch-');
@@ -40,7 +38,15 @@ export class ScSwitch implements FormCheckboxControl {
   readonly classInput = input<string>('', { alias: 'class' });
   readonly ariaDescribedByInput = input('', { alias: 'aria-describedby' });
   readonly checked = model<boolean>(false);
-  readonly disabledSignal = signal(false);
+
+  // Part of the FormUiControl contract, so the Field directive binds a
+  // disabled field straight to it.
+  readonly disabled = input<boolean, unknown>(false, {
+    transform: booleanAttribute,
+  });
+
+  // Kept for ScSwitchField, which derives its data-disabled from this.
+  readonly disabledSignal = computed(() => this.disabled());
 
   readonly id = computed(
     () => this.idInput() || this.switchField?.id() || this.fallbackId,
@@ -62,16 +68,8 @@ export class ScSwitch implements FormCheckboxControl {
     () => (this.touched() && this.invalid()) || null,
   );
 
-  constructor() {
-    effect(() => {
-      this.disabledSignal.set(this.elementRef.nativeElement.disabled);
-    });
-  }
-
   protected onInputChange(event: Event): void {
-    const input = event.target as HTMLInputElement;
-    this.checked.set(input.checked);
-    this.disabledSignal.set(input.disabled);
+    this.checked.set((event.target as HTMLInputElement).checked);
   }
 
   protected readonly class = computed(() =>


### PR DESCRIPTION
Follow-up to #1515. Neither control accepted `disabled` at all — they read the raw DOM property in a non-reactive effect:

```ts
effect(() => {
  this.disabledSignal.set(this.elementRef.nativeElement.disabled);
});
```

That reads no signals, so it runs **once and never again**, and `disabledSignal` only moved afterwards when `onInputChange` fired.

`ScCheckboxField` and `ScSwitchField` both derive their `data-disabled` from that signal — so in practice **a disabled checkbox never marked its field disabled at all**. The field's dimming and the control's real state simply disagreed.

`disabled` is also part of the `FormUiControl` contract, alongside the `invalid`/`touched` inputs from #1515, so declaring it means the `Field` directive binds a disabled Signal Forms field straight to the control.

`disabledSignal` stays, now a computed over the input, so the field components keep working unchanged.

## Why this was invisible

The native input kept being disabled either way — Angular was already binding `[disabled]` to the DOM property, since the directive declared no input of that name. So the control looked correct; only the field was wrong.

That also caught out my **first attempt at the tests**, which asserted on the native input and passed against *both* implementations. They were tautological. Rewritten to assert on the field's `data-disabled`, where the behaviour actually differs.

## Tests

8 added (34 total). **Two fail against the previous implementation** — `marks the field disabled when the control is disabled`, for both controls.

Worth noting the failure was sharper than I'd predicted: I described this as a staleness bug where the field would get stuck disabled. It's the opposite — the field never picked the state up in the first place. The test comment says so now.

## Verification

34/34 pass; verified the 2 fail on the old code by stashing just the two control files. `nx lint` across `ui` and `showcase` — 9 warnings before and after against a `git stash` baseline. `tsc --noEmit` exit 0; `validate-demo-code` 0 mismatches. Rebased onto `main` after #1515 merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)