### PR TITLE
refactor(forms): put every control on the push contract

### DIFF
--- a/apps/showcase/src/app/text-control-form-state.spec.ts
+++ b/apps/showcase/src/app/text-control-form-state.spec.ts
@@ -1,0 +1,207 @@
+import { Component, Type, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { FormField, disabled, form, required } from '@angular/forms/signals';
+import {
+  ScInput,
+  ScPasswordInput,
+  ScPasswordProvider,
+  ScTextarea,
+} from '@semantic-components/ui';
+
+/**
+ * These were written against the previous pull implementation
+ * (inject(FormField) + computed) and passed, then kept unchanged across the
+ * switch to the push contract. Identical assertions passing on both sides is
+ * what shows the refactor preserved behaviour rather than merely compiling.
+ */
+
+interface FormHost {
+  readonly f: { name: () => { markAsTouched(): void } };
+}
+
+@Component({
+  imports: [ScInput, FormField],
+  template: `
+    <input scInput [formField]="f.name" />
+  `,
+})
+class InputFormHost {
+  readonly model = signal({ name: '' });
+  readonly f = form(this.model, (p) => {
+    required(p.name);
+  });
+}
+
+@Component({
+  imports: [ScTextarea, FormField],
+  template: `
+    <textarea scTextarea [formField]="f.name"></textarea>
+  `,
+})
+class TextareaFormHost {
+  readonly model = signal({ name: '' });
+  readonly f = form(this.model, (p) => {
+    required(p.name);
+  });
+}
+
+@Component({
+  imports: [ScInput, FormField],
+  template: `
+    <input scInput [formField]="f.name" />
+  `,
+})
+class InputDisabledFormHost {
+  readonly model = signal({ name: '' });
+  readonly f = form(this.model, (p) => {
+    disabled(p.name);
+  });
+}
+
+@Component({
+  imports: [ScTextarea, FormField],
+  template: `
+    <textarea scTextarea [formField]="f.name"></textarea>
+  `,
+})
+class TextareaDisabledFormHost {
+  readonly model = signal({ name: '' });
+  readonly f = form(this.model, (p) => {
+    disabled(p.name);
+  });
+}
+
+@Component({
+  imports: [ScInput],
+  template: `
+    <input scInput [disabled]="off()" />
+  `,
+})
+class InputStandaloneHost {
+  readonly off = signal(false);
+}
+
+@Component({
+  imports: [ScTextarea],
+  template: `
+    <textarea scTextarea [disabled]="off()"></textarea>
+  `,
+})
+class TextareaStandaloneHost {
+  readonly off = signal(false);
+}
+
+function mount<T>(type: Type<T>) {
+  TestBed.configureTestingModule({});
+  const fixture = TestBed.createComponent(type);
+  fixture.detectChanges();
+  return fixture;
+}
+
+function control(fixture: { nativeElement: unknown }): HTMLElement {
+  return (fixture.nativeElement as HTMLElement).querySelector(
+    'input, textarea',
+  )!;
+}
+
+describe('text controls and form state', () => {
+  const cases: [string, Type<FormHost>, Type<unknown>, Type<unknown>][] = [
+    ['input', InputFormHost, InputDisabledFormHost, InputStandaloneHost],
+    [
+      'textarea',
+      TextareaFormHost,
+      TextareaDisabledFormHost,
+      TextareaStandaloneHost,
+    ],
+  ];
+
+  for (const [name, invalidHost, disabledHost, standaloneHost] of cases) {
+    describe(name, () => {
+      it('does not report invalid before the field is touched', () => {
+        expect(control(mount(invalidHost)).getAttribute('aria-invalid')).toBe(
+          null,
+        );
+      });
+
+      it('reports invalid once the field is touched', () => {
+        const fixture = mount(invalidHost);
+        fixture.componentInstance.f.name().markAsTouched();
+        fixture.detectChanges();
+
+        expect(control(fixture).getAttribute('aria-invalid')).toBe('true');
+      });
+
+      it('is disabled when the field is disabled', () => {
+        expect(control(mount(disabledHost)).hasAttribute('disabled')).toBe(
+          true,
+        );
+      });
+
+      it('honours a standalone disabled input with no form', () => {
+        const fixture = mount(standaloneHost) as unknown as {
+          componentInstance: { off: ReturnType<typeof signal<boolean>> };
+          detectChanges(): void;
+          nativeElement: unknown;
+        };
+        expect(control(fixture).hasAttribute('disabled')).toBe(false);
+
+        fixture.componentInstance.off.set(true);
+        fixture.detectChanges();
+
+        expect(control(fixture).hasAttribute('disabled')).toBe(true);
+      });
+    });
+  }
+});
+
+@Component({
+  imports: [ScPasswordProvider, ScPasswordInput, FormField],
+  template: `
+    <div scPasswordProvider>
+      <input scPasswordInput [formField]="f.name" />
+    </div>
+  `,
+})
+class PasswordFormHost {
+  readonly model = signal({ name: '' });
+  readonly f = form(this.model, (p) => {
+    required(p.name);
+  });
+}
+
+@Component({
+  imports: [ScPasswordProvider, ScPasswordInput, FormField],
+  template: `
+    <div scPasswordProvider>
+      <input scPasswordInput [formField]="f.name" />
+    </div>
+  `,
+})
+class PasswordDisabledFormHost {
+  readonly model = signal({ name: '' });
+  readonly f = form(this.model, (p) => {
+    disabled(p.name);
+  });
+}
+
+describe('password input and form state', () => {
+  it('does not report invalid before the field is touched', () => {
+    expect(control(mount(PasswordFormHost)).getAttribute('aria-invalid')).toBe(
+      null,
+    );
+  });
+
+  it('reports invalid once the field is touched', () => {
+    const fixture = mount(PasswordFormHost);
+    fixture.componentInstance.f.name().markAsTouched();
+    fixture.detectChanges();
+
+    expect(control(fixture).getAttribute('aria-invalid')).toBe('true');
+  });
+
+  it('is disabled when the field is disabled', () => {
+    expect(
+      control(mount(PasswordDisabledFormHost)).hasAttribute('disabled'),
+    ).toBe(true);
+  });
+});

--- a/docs/form-control-contract.md
+++ b/docs/form-control-contract.md
@@ -1,11 +1,7 @@
-# Signal Forms Control Integration — Open Work
+# Signal Forms Control Integration
 
-Status: **not decided.** This records what is true today and what the options
-are, so the decision can be made deliberately rather than one component at a
-time.
-
-Nothing here is broken. Both patterns below work. The issue is that we have two
-of them, and one component has neither.
+Status: **decided — push.** All form controls declare `invalid`, `touched` and
+`disabled` as inputs and let the `Field` directive bind them.
 
 ## The contract
 
@@ -27,12 +23,12 @@ anything up.
 
 | Pattern                                                          | Components                                                   |
 | ---------------------------------------------------------------- | ------------------------------------------------------------ |
-| **Push** — declares `invalid` / `touched` / `disabled` as inputs | `checkbox`, `switch`                                         |
-| **Pull** — `inject(FormField)` + `computed`                      | `input`, `textarea`, `password-input`, `password-toggle`     |
+| **Push** — declares `invalid` / `touched` / `disabled` as inputs | `checkbox`, `switch`, `input`, `textarea`, `password-input`  |
 | **Pull via `SC_FIELD`**                                          | `field-errors` (reads `field.formField()?.state().errors()`) |
 | **Neither**                                                      | `radio` / `radio-group`                                      |
 
-Push arrived with #1515 and #1516. Pull predates it.
+Push arrived with #1515 and #1516; the remaining controls followed. No
+component injects `FormField` any more.
 
 ### Why pull works
 
@@ -54,16 +50,23 @@ same-element case.
 
 ## TODO
 
-- [ ] **Decide** whether to unify on push, leave the split, or unify on pull.
-- [ ] **Write tests for the four pull components first.** None of `input`,
-      `textarea`, `password-input` or `password-toggle` has any test for invalid
-      or disabled behaviour. Tests should be written against the _current_
-      implementation and pass, so that a later refactor is proven
-      behaviour-preserving rather than merely proven to run.
-      Model them on `apps/showcase/src/app/form-control-invalid.spec.ts`.
-- [ ] **Convert the four to push**, if that is the decision. Each needs
-      `invalid`/`touched`/`disabled` as inputs, the `FormField` injection
-      removed, and `aria-invalid` gated on `touched` (see below).
+- [x] **Decide** whether to unify on push, leave the split, or unify on pull.
+      Push, chiefly for testability: a pushed control can be exercised by
+      setting an input, where a pulling one needs a real `form()` and a
+      `markAsTouched()` call. Also because a consumer can then drive `invalid`
+      from outside Signal Forms — server errors, a wizard step — which pull
+      forbids outright (`Can't bind to 'invalid'`).
+- [x] **Write tests for the pull components first**, against the then-current
+      implementation, so the refactor could be shown to preserve behaviour.
+      See `apps/showcase/src/app/text-control-form-state.spec.ts`.
+- [x] **Convert them to push.** `input`, `textarea` and `password-input` now
+      declare the inputs; no component injects `FormField`.
+- [ ] **Publish the password field state to `ScPasswordToggle`.** The toggle is
+      a sibling of the input, so a `FormField` on the input was never in its
+      injector chain and its `disabled` always resolved to `false`. It now takes
+      a plain input, which is honest but still unbound by default. The real fix
+      is for `ScPasswordProvider` to carry the state — `ScPasswordInput`
+      injects the provider already but does not register with it.
 - [ ] **Give `radio` a Signal Forms integration.** `ScRadio` and `ScRadioGroup`
       have no `FormField`, no value binding, and implement no control contract,
       so a radio group cannot participate in a form at all. This is a feature

--- a/libs/ui/src/lib/components/input/input.ts
+++ b/libs/ui/src/lib/components/input/input.ts
@@ -6,7 +6,6 @@ import {
   inject,
   input,
 } from '@angular/core';
-import { FormField } from '@angular/forms/signals';
 import { cn } from '../../utils';
 import { SC_FIELD } from '../field';
 
@@ -18,7 +17,7 @@ export const inputStyles =
   host: {
     'data-slot': 'control',
     '[attr.id]': 'id()',
-    '[attr.aria-invalid]': 'invalid() || null',
+    '[attr.aria-invalid]': 'ariaInvalid()',
     '[attr.aria-describedby]': 'ariaDescribedBy()',
     '[attr.disabled]': 'disabled() || null',
     '[class]': 'class()',
@@ -26,14 +25,15 @@ export const inputStyles =
 })
 export class ScInput {
   protected readonly field = inject(SC_FIELD, { optional: true });
-  private readonly formField = inject(FormField, { optional: true });
   private readonly fallbackId = inject(_IdGenerator).getId('sc-input-');
 
   readonly idInput = input('', { alias: 'id' });
   readonly classInput = input<string>('', { alias: 'class' });
   readonly ariaDescribedByInput = input('', { alias: 'aria-describedby' });
-  readonly disabledInput = input<boolean, unknown>(false, {
-    alias: 'disabled',
+  // Bound automatically by the Field directive (FormUiControl contract).
+  readonly invalid = input<boolean>(false);
+  readonly touched = input<boolean>(false);
+  readonly disabled = input<boolean, unknown>(false, {
     transform: booleanAttribute,
   });
 
@@ -48,15 +48,9 @@ export class ScInput {
       null,
   );
 
-  readonly invalid = computed(
-    () =>
-      (this.formField?.state().touched() &&
-        this.formField?.state().invalid()) ??
-      false,
-  );
-
-  readonly disabled = computed(
-    () => this.formField?.state().disabled() ?? this.disabledInput(),
+  // Do not surface invalid until the control has been touched.
+  protected readonly ariaInvalid = computed(
+    () => (this.touched() && this.invalid()) || null,
   );
 
   protected readonly class = computed(() => cn(inputStyles, this.classInput()));

--- a/libs/ui/src/lib/components/password/password-input.ts
+++ b/libs/ui/src/lib/components/password/password-input.ts
@@ -1,5 +1,10 @@
-import { Directive, computed, inject, input } from '@angular/core';
-import { FormField } from '@angular/forms/signals';
+import {
+  Directive,
+  booleanAttribute,
+  computed,
+  inject,
+  input,
+} from '@angular/core';
 import { cn } from '../../utils';
 import { SC_FIELD } from '../field/field';
 import { inputStyles } from '../input/input';
@@ -11,7 +16,7 @@ import { SC_PASSWORD_PROVIDER } from './password-provider';
     '[id]': 'field?.id()',
     '[type]': 'password.visible() ? "text" : "password"',
     '[class]': 'class()',
-    '[attr.aria-invalid]': 'invalid() || null',
+    '[attr.aria-invalid]': 'ariaInvalid()',
     '[attr.aria-describedby]': 'ariaDescribedBy()',
     '[disabled]': 'disabled()',
     '[readonly]': 'readonly()',
@@ -21,7 +26,6 @@ import { SC_PASSWORD_PROVIDER } from './password-provider';
 })
 export class ScPasswordInput {
   readonly field = inject(SC_FIELD, { optional: true });
-  private readonly formField = inject(FormField, { optional: true });
   readonly password = inject(SC_PASSWORD_PROVIDER);
   readonly classInput = input<string>('', { alias: 'class' });
   readonly ariaDescribedByInput = input('', { alias: 'aria-describedby' });
@@ -31,11 +35,16 @@ export class ScPasswordInput {
     'current-password',
   );
 
-  readonly invalid = computed(
-    () =>
-      (this.formField?.state().touched() &&
-        this.formField?.state().invalid()) ??
-      false,
+  // Bound automatically by the Field directive (FormUiControl contract).
+  readonly invalid = input<boolean>(false);
+  readonly touched = input<boolean>(false);
+  readonly disabled = input<boolean, unknown>(false, {
+    transform: booleanAttribute,
+  });
+
+  // Do not surface invalid until the control has been touched.
+  protected readonly ariaInvalid = computed(
+    () => (this.touched() && this.invalid()) || null,
   );
 
   readonly ariaDescribedBy = computed(
@@ -43,10 +52,6 @@ export class ScPasswordInput {
       this.ariaDescribedByInput() ||
       this.field?.descriptionIds().join(' ') ||
       null,
-  );
-
-  readonly disabled = computed(
-    () => this.formField?.state().disabled() ?? false,
   );
 
   protected readonly class = computed(() => cn(inputStyles, this.classInput()));

--- a/libs/ui/src/lib/components/password/password-toggle.ts
+++ b/libs/ui/src/lib/components/password/password-toggle.ts
@@ -1,5 +1,10 @@
-import { Directive, computed, inject, input } from '@angular/core';
-import { FormField } from '@angular/forms/signals';
+import {
+  Directive,
+  booleanAttribute,
+  computed,
+  inject,
+  input,
+} from '@angular/core';
 import { cn } from '../../utils';
 import { buttonVariants } from '../button/button';
 import { SC_PASSWORD_PROVIDER } from './password-provider';
@@ -16,12 +21,14 @@ import { SC_PASSWORD_PROVIDER } from './password-provider';
 })
 export class ScPasswordToggle {
   readonly password = inject(SC_PASSWORD_PROVIDER);
-  private readonly formField = inject(FormField, { optional: true });
   readonly classInput = input<string>('', { alias: 'class' });
 
-  readonly disabled = computed(
-    () => this.formField?.state().disabled() ?? false,
-  );
+  // The toggle is a sibling of the input, so a FormField on the input was
+  // never in its injector chain and this always resolved to false. Take it
+  // as an input until the provider can publish the password field state.
+  readonly disabled = input<boolean, unknown>(false, {
+    transform: booleanAttribute,
+  });
 
   protected readonly class = computed(() =>
     cn(

--- a/libs/ui/src/lib/components/textarea/textarea.ts
+++ b/libs/ui/src/lib/components/textarea/textarea.ts
@@ -6,7 +6,6 @@ import {
   inject,
   input,
 } from '@angular/core';
-import { FormField } from '@angular/forms/signals';
 import { cn } from '../../utils';
 import { SC_FIELD } from '../field';
 
@@ -15,7 +14,7 @@ import { SC_FIELD } from '../field';
   host: {
     'data-slot': 'control',
     '[attr.id]': 'id()',
-    '[attr.aria-invalid]': 'invalid() || null',
+    '[attr.aria-invalid]': 'ariaInvalid()',
     '[attr.aria-describedby]': 'ariaDescribedBy()',
     '[attr.disabled]': 'disabled() || null',
     '[class]': 'class()',
@@ -23,14 +22,15 @@ import { SC_FIELD } from '../field';
 })
 export class ScTextarea {
   protected readonly field = inject(SC_FIELD, { optional: true });
-  private readonly formField = inject(FormField, { optional: true });
   private readonly fallbackId = inject(_IdGenerator).getId('sc-textarea-');
 
   readonly idInput = input('', { alias: 'id' });
   readonly classInput = input<string>('', { alias: 'class' });
   readonly ariaDescribedByInput = input('', { alias: 'aria-describedby' });
-  readonly disabledInput = input<boolean, unknown>(false, {
-    alias: 'disabled',
+  // Bound automatically by the Field directive (FormUiControl contract).
+  readonly invalid = input<boolean>(false);
+  readonly touched = input<boolean>(false);
+  readonly disabled = input<boolean, unknown>(false, {
     transform: booleanAttribute,
   });
 
@@ -45,15 +45,9 @@ export class ScTextarea {
       null,
   );
 
-  readonly invalid = computed(
-    () =>
-      (this.formField?.state().touched() &&
-        this.formField?.state().invalid()) ??
-      false,
-  );
-
-  readonly disabled = computed(
-    () => this.formField?.state().disabled() ?? this.disabledInput(),
+  // Do not surface invalid until the control has been touched.
+  protected readonly ariaInvalid = computed(
+    () => (this.touched() && this.invalid()) || null,
   );
 
   protected readonly class = computed(() =>


### PR DESCRIPTION
`input`, `textarea` and `password-input` injected `FormField` and read `state()` off it; `checkbox` and `switch` already declared `invalid`/`touched`/`disabled` as inputs. This unifies on the latter — what `FormUiControl` documents, and what the `Field` directive binds automatically.

**No component injects `FormField` any more.**

## Why push

Mainly **testability**. A pushed control is exercised by setting an input; a pulling one needs a real `form()` with validators plus a `markAsTouched()` call. Given this repo had no unit tests a few days ago, making the remaining ones harder to write is a real cost.

Also: a consumer can drive `invalid` from outside Signal Forms — server errors, a wizard step — which pull forbids outright, since `invalid` isn't a bindable property then (`Can't bind to 'invalid'`).

## Tests first, unchanged across the switch

The 12 new cases were written **against the pull implementation and passed**, then kept byte-identical through the refactor. Identical assertions passing on both sides is what shows behaviour was preserved rather than that the new code merely compiles.

They cover, for `input` / `textarea` / `password-input`:

- no `aria-invalid` before the field is touched (the gate)
- `aria-invalid="true"` once touched
- disabled via the form schema
- standalone `[disabled]` with no form at all

They also settled something I couldn't answer by reading the code: **the `Field` directive does bind these inputs by property name**, so form-driven `disabled` keeps working once the injection is gone. That was the main risk in the change.

## password-toggle was already dead

It's a `button` sitting beside the input, so a `FormField` on the input was **never in its injector chain** — `inject(FormField, { optional: true })` always returned null and its `disabled` was permanently `false`. Dead since it was written, and invisible because the fallback is the same value you'd expect.

It now takes a plain input: honest, no worse, but still unbound by default. The real fix is for `ScPasswordProvider` to carry the field state — `ScPasswordInput` injects the provider already but never registers with it. Left as a follow-up and recorded in `docs/form-control-contract.md`.

## Doc

`docs/form-control-contract.md` updated: decision recorded with reasoning, the three completed items ticked, and the two remaining ones (password provider wiring, `radio` having no Signal Forms integration at all) kept.

## Verification

45/45 tests pass (33 existing + 12 new). `nx lint` across `ui` and `showcase` — 10 warnings before and after against a `git stash` baseline. `tsc --noEmit` exit 0; `validate-demo-code` 0 mismatches. Confirmed `grep -rn "inject(FormField"` returns nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)