### PR TITLE
fix(password): let the toggle follow the field's disabled state

### DIFF
--- a/apps/showcase/src/app/text-control-form-state.spec.ts
+++ b/apps/showcase/src/app/text-control-form-state.spec.ts
@@ -5,6 +5,7 @@ import {
   ScInput,
   ScPasswordInput,
   ScPasswordProvider,
+  ScPasswordToggle,
   ScTextarea,
 } from '@semantic-components/ui';
 
@@ -203,5 +204,46 @@ describe('password input and form state', () => {
     expect(
       control(mount(PasswordDisabledFormHost)).hasAttribute('disabled'),
     ).toBe(true);
+  });
+});
+
+@Component({
+  imports: [ScPasswordProvider, ScPasswordInput, ScPasswordToggle, FormField],
+  template: `
+    <div scPasswordProvider>
+      <input scPasswordInput [formField]="f.name" />
+      <button scPasswordToggle type="button">show</button>
+    </div>
+  `,
+})
+class PasswordToggleHost {
+  readonly off = signal(false);
+  readonly model = signal({ name: '' });
+  readonly f = form(this.model, (p) => {
+    disabled(p.name, { when: () => this.off() });
+  });
+}
+
+describe('password toggle disabled', () => {
+  function toggle(fixture: { nativeElement: unknown }): HTMLButtonElement {
+    const button = (fixture.nativeElement as HTMLElement).querySelector(
+      'button',
+    );
+    if (!button) throw new Error('no toggle button rendered');
+    return button;
+  }
+
+  it('is enabled while the field is enabled', () => {
+    expect(toggle(mount(PasswordToggleHost)).disabled).toBe(false);
+  });
+
+  it('follows the field into the disabled state', () => {
+    const fixture = mount(PasswordToggleHost);
+    fixture.componentInstance.off.set(true);
+    fixture.detectChanges();
+
+    // The toggle is a sibling of the input, so it cannot see the field
+    // directly; ScPasswordProvider queries it and passes the state along.
+    expect(toggle(fixture).disabled).toBe(true);
   });
 });

--- a/docs/form-control-contract.md
+++ b/docs/form-control-contract.md
@@ -27,8 +27,10 @@ anything up.
 | **Pull via `SC_FIELD`**                                          | `field-errors` (reads `field.formField()?.state().errors()`) |
 | **Neither**                                                      | `radio` / `radio-group`                                      |
 
-Push arrived with #1515 and #1516; the remaining controls followed. No
-component injects `FormField` any more.
+Push arrived with #1515 and #1516; the remaining controls followed. No control
+injects `FormField` any more. `ScPasswordProvider` is the one place that still
+reaches for it, and it queries rather than injects — see the password note under
+TODO.
 
 ### Why pull works
 
@@ -61,12 +63,13 @@ same-element case.
       See `apps/showcase/src/app/text-control-form-state.spec.ts`.
 - [x] **Convert them to push.** `input`, `textarea` and `password-input` now
       declare the inputs; no component injects `FormField`.
-- [ ] **Publish the password field state to `ScPasswordToggle`.** The toggle is
-      a sibling of the input, so a `FormField` on the input was never in its
-      injector chain and its `disabled` always resolved to `false`. It now takes
-      a plain input, which is honest but still unbound by default. The real fix
-      is for `ScPasswordProvider` to carry the state — `ScPasswordInput`
-      injects the provider already but does not register with it.
+- [x] **Publish the password field state to `ScPasswordToggle`.** The toggle is
+      a button beside the input, so the field on the input is neither in its
+      injector chain nor injectable from the provider above it — injection only
+      walks up, never down. `ScPasswordProvider` therefore _queries_ it with
+      `contentChild(FormField)` and exposes `disabled`; the toggle ORs that with
+      its own `disabled` input. Before this, the toggle's `disabled` was
+      permanently `false`.
 - [ ] **Give `radio` a Signal Forms integration.** `ScRadio` and `ScRadioGroup`
       have no `FormField`, no value binding, and implement no control contract,
       so a radio group cannot participate in a form at all. This is a feature

--- a/libs/ui/src/lib/components/password/password-provider.ts
+++ b/libs/ui/src/lib/components/password/password-provider.ts
@@ -2,9 +2,11 @@ import {
   Directive,
   InjectionToken,
   computed,
+  contentChild,
   input,
   model,
 } from '@angular/core';
+import { FormField } from '@angular/forms/signals';
 import { cn } from '../../utils';
 
 export const SC_PASSWORD_PROVIDER = new InjectionToken<ScPasswordProvider>(
@@ -26,6 +28,18 @@ export class ScPasswordProvider {
   protected readonly class = computed(() => cn('contents', this.classInput()));
 
   readonly visible = model(false);
+
+  /**
+   * The field lives on the input, which is a descendant, so it cannot be
+   * injected from here — it has to be queried. The toggle is a sibling of the
+   * input and cannot reach it at all, so the provider reads the state on its
+   * behalf.
+   */
+  private readonly formField = contentChild(FormField);
+
+  readonly disabled = computed(
+    () => this.formField()?.state().disabled() ?? false,
+  );
 
   toggle(): void {
     this.visible.update((v) => !v);

--- a/libs/ui/src/lib/components/password/password-toggle.ts
+++ b/libs/ui/src/lib/components/password/password-toggle.ts
@@ -23,12 +23,15 @@ export class ScPasswordToggle {
   readonly password = inject(SC_PASSWORD_PROVIDER);
   readonly classInput = input<string>('', { alias: 'class' });
 
-  // The toggle is a sibling of the input, so a FormField on the input was
-  // never in its injector chain and this always resolved to false. Take it
-  // as an input until the provider can publish the password field state.
-  readonly disabled = input<boolean, unknown>(false, {
+  readonly disabledInput = input<boolean, unknown>(false, {
+    alias: 'disabled',
     transform: booleanAttribute,
   });
+
+  // The field lives on the input, a sibling, so the provider reads it for us.
+  readonly disabled = computed(
+    () => this.disabledInput() || this.password.disabled(),
+  );
 
   protected readonly class = computed(() =>
     cn(


### PR DESCRIPTION
`ScPasswordToggle`'s `disabled` was **permanently `false`** — the dead path found in #1518, now actually fixed rather than just made honest.

## Why it couldn't see the field

The toggle is a `button` sitting beside the input:

```html
<div scPasswordProvider>
  <input scPasswordInput [formField]="form.password" />
  <div scInputGroupAddon>
    <button scPasswordToggle>…</button>
  </div>
</div>
```

`FormField` is on the input, so it's not in the button's injector chain. **And it isn't injectable from the provider either** — injection only walks *up*, never down, so the wrapping provider can't reach a directive on its own descendant.

## What works instead

A content query — the same mechanism `ScCheckboxField` already uses to reach its checkbox:

```ts
private readonly formField = contentChild(FormField);
readonly disabled = computed(() => this.formField()?.state().disabled() ?? false);
```

The toggle ORs that with its own `disabled` input, so it follows a disabled password field while a consumer can still disable it directly.

Note this is a *query*, not an injection, so it doesn't reintroduce the pull pattern #1518 removed — and the provider isn't a form control, it's a coordinator for two siblings that can't see each other.

## Tests

2 added (47 total). The second **fails against the previous code**: with the field disabled, the toggle stayed enabled.

## Verification

47/47 pass; confirmed the new test fails on the old code by stashing just `libs/ui/src/lib/components/password/`. `nx lint` across `ui` and `showcase` — **10 warnings, matching baseline**. My first version of the test helper added an 11th (a non-null assertion); fixed rather than shipped. `tsc --noEmit` exit 0; `validate-demo-code` 0 mismatches.

`docs/form-control-contract.md` updated — that TODO ticked off, and the "no component injects FormField" line corrected, since the provider does reach for it, just by query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)