### PR TITLE
fix(radio): report invalid state via aria-invalid

### DIFF
--- a/apps/showcase/src/app/radio-form.spec.ts
+++ b/apps/showcase/src/app/radio-form.spec.ts
@@ -1,0 +1,91 @@
+import { Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { FormField, disabled, form, required } from '@angular/forms/signals';
+import { ScRadio, ScRadioGroup } from '@semantic-components/ui';
+
+@Component({
+  imports: [ScRadioGroup, ScRadio, FormField],
+  template: `
+    <div scRadioGroup>
+      <input type="radio" scRadio value="a" [formField]="f.pick" />
+      <input type="radio" scRadio value="b" [formField]="f.pick" />
+    </div>
+  `,
+})
+class RadioFormHost {
+  readonly off = signal(false);
+  readonly model = signal({ pick: '' });
+  readonly f = form(this.model, (p) => {
+    disabled(p.pick, { when: () => this.off() });
+  });
+}
+
+function mount() {
+  TestBed.configureTestingModule({});
+  const fixture = TestBed.createComponent(RadioFormHost);
+  fixture.detectChanges();
+  return fixture;
+}
+
+function radios(fixture: ReturnType<typeof mount>) {
+  return Array.from(
+    (fixture.nativeElement as HTMLElement).querySelectorAll('input'),
+  );
+}
+
+describe('radio and Signal Forms', () => {
+  it('writes the selected value into the model', () => {
+    const fixture = mount();
+    const [, second] = radios(fixture);
+
+    second.click();
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.model().pick).toBe('b');
+  });
+
+  it('reflects a model value onto the matching radio', () => {
+    const fixture = mount();
+    fixture.componentInstance.model.set({ pick: 'a' });
+    fixture.detectChanges();
+
+    expect(radios(fixture)[0].checked).toBe(true);
+  });
+
+  it('disables every radio when the field is disabled', () => {
+    const fixture = mount();
+    fixture.componentInstance.off.set(true);
+    fixture.detectChanges();
+
+    expect(radios(fixture).map((r) => r.disabled)).toEqual([true, true]);
+  });
+});
+
+@Component({
+  imports: [ScRadioGroup, ScRadio, FormField],
+  template: `
+    <div scRadioGroup>
+      <input type="radio" scRadio value="a" [formField]="f.pick" />
+    </div>
+  `,
+})
+class RadioInvalidHost {
+  readonly model = signal({ pick: '' });
+  readonly f = form(this.model, (p) => {
+    required(p.pick);
+  });
+}
+
+describe('radio invalid state', () => {
+  it('reports aria-invalid once the field is touched', () => {
+    TestBed.configureTestingModule({});
+    const fixture = TestBed.createComponent(RadioInvalidHost);
+    fixture.detectChanges();
+
+    fixture.componentInstance.f.pick().markAsTouched();
+    fixture.detectChanges();
+
+    const radio = (fixture.nativeElement as HTMLElement).querySelector('input');
+    expect(radio?.getAttribute('aria-invalid')).toBe('true');
+  });
+});

--- a/docs/form-control-contract.md
+++ b/docs/form-control-contract.md
@@ -24,8 +24,21 @@ anything up.
 | Pattern                                                          | Components                                                   |
 | ---------------------------------------------------------------- | ------------------------------------------------------------ |
 | **Push** — declares `invalid` / `touched` / `disabled` as inputs | `checkbox`, `switch`, `input`, `textarea`, `password-input`  |
+| **Push, partial** — `invalid` / `touched` only                   | `radio` (see below)                                          |
 | **Pull via `SC_FIELD`**                                          | `field-errors` (reads `field.formField()?.state().errors()`) |
-| **Neither**                                                      | `radio` / `radio-group`                                      |
+
+### Radio is a special case
+
+`ScRadio` implements no control contract, and for a long time I assumed that
+meant a radio group could not participate in a form. **That was wrong.** A
+native `<input type="radio">` with `[formField]` is handled by Signal Forms'
+built-in native-input support: value, checked reflection and disabled all work
+with no contract on our side. `apps/showcase/src/app/radio-form.spec.ts` pins
+this down.
+
+The one thing that support does _not_ provide is `aria-invalid`, so `ScRadio`
+declares `invalid` and `touched` as inputs purely to surface that. It has no
+`value` model of its own and does not need one.
 
 Push arrived with #1515 and #1516; the remaining controls followed. No control
 injects `FormField` any more. `ScPasswordProvider` is the one place that still
@@ -70,11 +83,11 @@ same-element case.
       `contentChild(FormField)` and exposes `disabled`; the toggle ORs that with
       its own `disabled` input. Before this, the toggle's `disabled` was
       permanently `false`.
-- [ ] **Give `radio` a Signal Forms integration.** `ScRadio` and `ScRadioGroup`
-      have no `FormField`, no value binding, and implement no control contract,
-      so a radio group cannot participate in a form at all. This is a feature
-      gap, not a refactor, and it is why radio was excluded from #1515 and
-      #1516. Likely wants `FormValueControl` on the group rather than the item.
+- [x] **Give `radio` a Signal Forms integration.** It turned out to have one
+      already, via native-input support — see the radio section above. The only
+      genuine gap was `aria-invalid`, now surfaced through `invalid`/`touched`
+      inputs. No `FormValueControl` on the group is needed, which is what I had
+      expected to write.
 - [ ] **Decide about `errors` and `disabledReasons`.** No component declares
       either as an input. `ScFieldErrors` uses a third variant: it pulls through
       the `SC_FIELD` context rather than injecting `FormField` directly —

--- a/libs/ui/src/lib/components/radio-group/radio.ts
+++ b/libs/ui/src/lib/components/radio-group/radio.ts
@@ -16,6 +16,7 @@ import { ScRadioGroup } from './radio-group';
     'data-slot': 'radio',
     '[attr.id]': 'id()',
     '[attr.aria-describedby]': 'ariaDescribedBy()',
+    '[attr.aria-invalid]': 'ariaInvalid()',
     '[class]': 'class()',
     '[disabled]': 'disabled()',
   },
@@ -50,6 +51,17 @@ export class ScRadio {
     () => this.disabledInput() || (this.radioGroup?.disabled() ?? false),
   );
 
+  // Bound automatically by the Field directive (FormUiControl contract).
+  // Value, checked and disabled already come from its native-input support;
+  // aria-invalid does not, so it has to be surfaced here.
+  readonly invalid = input<boolean>(false);
+  readonly touched = input<boolean>(false);
+
+  // Do not surface invalid until the control has been touched.
+  protected readonly ariaInvalid = computed(
+    () => (this.touched() && this.invalid()) || null,
+  );
+
   protected readonly class = computed(() =>
     cn(
       'relative',
@@ -57,6 +69,9 @@ export class ScRadio {
       'aspect-square h-4 w-4 rounded-full border border-input dark:bg-input/30 transition-colors disabled:cursor-not-allowed disabled:opacity-50',
       'checked:bg-primary checked:border-primary checked:text-primary-foreground',
       'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-3',
+      'aria-invalid:border-destructive aria-invalid:ring-destructive/20 aria-invalid:ring-3',
+      'dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40',
+      'aria-invalid:checked:border-primary',
       "[&::before]:content-['']",
       '[&::before]:absolute [&::before]:top-1/2 [&::before]:left-1/2 [&::before]:-translate-x-1/2 [&::before]:-translate-y-1/2 [&::before]:size-2 [&::before]:rounded-full [&::before]:bg-primary-foreground [&::before]:opacity-0 [&::before]:transform [&::before]:scale-0 [&::before]:transition-all [&::before]:duration-200',
       'checked:[&::before]:opacity-100 checked:[&::before]:scale-100',


### PR DESCRIPTION
## Correction first

I said repeatedly — across #1511, #1514, #1515 and #1516, and in `docs/form-control-contract.md` — that `ScRadio` has **no Signal Forms integration** and that a radio group **cannot participate in a form at all**.

**That was wrong.** A native `<input type="radio">` carrying `[formField]` is handled by Signal Forms' built-in native-input support. Value, checked reflection and disabled all work with no contract on our side — which is why the radio demos have always worked.

I'd inferred the gap from the absence of `FormValueControl` rather than testing it. Testing it first is what caught it here.

## What was actually missing

Only `aria-invalid`. That one native-input support does not provide, so radio was the last control not reporting invalid state to assistive technology.

Surfaced the same way as the others: `invalid`/`touched` inputs bound by the `Field` directive, gated on `touched`, plus the matching destructive border and ring from upstream's `.cn-radio-group-item` — including `aria-invalid:checked:border-primary`, which keeps the primary border on a *selected* invalid radio (verified it compiles to `[aria-invalid="true"]:checked`).

No `FormValueControl` on the group, which is what the TODO expected to be needed.

## Tests

4 added (51 total), and they split two ways deliberately:

- **Three pass against the unchanged code.** They exist to pin down the behaviour I had wrongly described — writing the selection into the model, reflecting a model value onto the matching radio, and disabling every radio when the field is disabled. Without them the same mistaken assumption could be made again.
- **One fails without this change** — `reports aria-invalid once the field is touched`.

## Verification

51/51 pass; confirmed the fourth fails on the old code by stashing `libs/ui/src/lib/components/radio-group/`. `nx lint` across `ui` and `showcase` — 10 warnings, matching baseline. `tsc --noEmit` exit 0; `validate-demo-code` 0 mismatches.

`docs/form-control-contract.md` corrected: the radio TODO is closed with an explanation of what was actually wrong, and a "Radio is a special case" section replaces the incorrect table row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)