### PR TITLE
test(field): pin down field error rendering; close the errors question

### DIFF
--- a/apps/showcase/src/app/field-errors.spec.ts
+++ b/apps/showcase/src/app/field-errors.spec.ts
@@ -1,0 +1,82 @@
+import { Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { FormField, form, minLength } from '@angular/forms/signals';
+import {
+  ScField,
+  ScFieldErrors,
+  ScInput,
+  ScInputGroup,
+} from '@semantic-components/ui';
+
+@Component({
+  imports: [ScField, ScFieldErrors, ScInput, FormField],
+  template: `
+    <div scField>
+      <input scInput [formField]="f.name" />
+      <div scFieldErrors></div>
+    </div>
+  `,
+})
+class FlatHost {
+  readonly model = signal({ name: 'ab' });
+  readonly f = form(this.model, (p) => {
+    minLength(p.name, 3, { message: 'Too short' });
+  });
+}
+
+/** The control sits inside an input group, so it is not a direct child. */
+@Component({
+  imports: [ScField, ScFieldErrors, ScInput, ScInputGroup, FormField],
+  template: `
+    <div scField>
+      <div scInputGroup>
+        <input scInput [formField]="f.name" />
+      </div>
+      <div scFieldErrors></div>
+    </div>
+  `,
+})
+class NestedHost {
+  readonly model = signal({ name: 'ab' });
+  readonly f = form(this.model, (p) => {
+    minLength(p.name, 3, { message: 'Too short' });
+  });
+}
+
+function mount(type: typeof FlatHost | typeof NestedHost) {
+  TestBed.configureTestingModule({});
+  const fixture = TestBed.createComponent(type);
+  fixture.detectChanges();
+  return fixture;
+}
+
+function errorsEl(fixture: { nativeElement: unknown }) {
+  const el = (fixture.nativeElement as HTMLElement).querySelector(
+    '[scFieldErrors]',
+  );
+  if (!el) throw new Error('no errors element rendered');
+  return el;
+}
+
+describe('field errors', () => {
+  for (const [name, type] of [
+    ['direct child', FlatHost],
+    ['nested in an input group', NestedHost],
+  ] as const) {
+    describe(name, () => {
+      it('stays hidden before the field is touched', () => {
+        expect(errorsEl(mount(type)).hasAttribute('hidden')).toBe(true);
+      });
+
+      it('shows the message once touched and invalid', () => {
+        const fixture = mount(type);
+        fixture.componentInstance.f.name().markAsTouched();
+        fixture.detectChanges();
+
+        const el = errorsEl(fixture);
+        expect(el.hasAttribute('hidden')).toBe(false);
+        expect(el.textContent?.trim()).toBe('Too short');
+      });
+    });
+  }
+});

--- a/docs/form-control-contract.md
+++ b/docs/form-control-contract.md
@@ -21,11 +21,11 @@ anything up.
 
 ## Where we are
 
-| Pattern                                                          | Components                                                   |
-| ---------------------------------------------------------------- | ------------------------------------------------------------ |
-| **Push** — declares `invalid` / `touched` / `disabled` as inputs | `checkbox`, `switch`, `input`, `textarea`, `password-input`  |
-| **Push, partial** — `invalid` / `touched` only                   | `radio` (see below)                                          |
-| **Pull via `SC_FIELD`**                                          | `field-errors` (reads `field.formField()?.state().errors()`) |
+| Pattern                                                          | Components                                                        |
+| ---------------------------------------------------------------- | ----------------------------------------------------------------- |
+| **Push** — declares `invalid` / `touched` / `disabled` as inputs | `checkbox`, `switch`, `input`, `textarea`, `password-input`       |
+| **Push, partial** — `invalid` / `touched` only                   | `radio` (see below)                                               |
+| **Container** — queries the field with `contentChild(FormField)` | `field`, `password-provider`; `field-errors` reads via `SC_FIELD` |
 
 ### Radio is a special case
 
@@ -42,8 +42,8 @@ declares `invalid` and `touched` as inputs purely to surface that. It has no
 
 Push arrived with #1515 and #1516; the remaining controls followed. No control
 injects `FormField` any more. `ScPasswordProvider` is the one place that still
-reaches for it, and it queries rather than injects — see the password note under
-TODO.
+reaches for it, and it queries rather than injects — see "Controls versus
+containers" below.
 
 ### Why pull works
 
@@ -63,7 +63,7 @@ same-element case.
 - It is less code. The push version of checkbox/switch came out smaller than the
   pull version I wrote first.
 
-## TODO
+## Decisions
 
 - [x] **Decide** whether to unify on push, leave the split, or unify on pull.
       Push, chiefly for testability: a pushed control can be exercised by
@@ -88,14 +88,30 @@ same-element case.
       genuine gap was `aria-invalid`, now surfaced through `invalid`/`touched`
       inputs. No `FormValueControl` on the group is needed, which is what I had
       expected to write.
-- [ ] **Decide about `errors` and `disabledReasons`.** No component declares
-      either as an input. `ScFieldErrors` uses a third variant: it pulls through
-      the `SC_FIELD` context rather than injecting `FormField` directly —
-      `field.formField()?.state().errors()`, already gated on
-      `touched() && invalid()`. So the split is really three ways, not two.
-      Worth deciding whether that one stays as-is; reading from the field
-      context is arguably right for a component that renders _the field's_
-      errors rather than its own.
+- [x] **Decide about `errors` and `disabledReasons`.** Leave them as they are.
+      See "Controls versus containers" below — `ScFieldErrors` is not a third,
+      inconsistent pattern, it is the container one.
+
+## Controls versus containers
+
+Two roles, and they need different mechanisms.
+
+**Controls** declare inputs and let the `Field` directive push state in. This is
+everything in the first two rows of the table above.
+
+**Containers** query downward with `contentChild(FormField)`, because the field
+lives on a descendant and injection only walks up. `ScField` does this,
+`ScPasswordProvider` does it since #1519, and `ScFieldErrors` reads the result
+through `SC_FIELD`.
+
+Declaring `errors` as an input on `ScFieldErrors` would be **dead code**: it is
+not a form control, nothing binds `[formField]` to it, so the `Field` directive
+would never populate the input. That is the same trap the password toggle's
+`disabled` fell into.
+
+`apps/showcase/src/app/field-errors.spec.ts` pins this down, including a control
+nested inside an input group rather than sitting as a direct child — the case
+where a downward query could plausibly miss.
 
 ## Gotchas to carry into the work
 


### PR DESCRIPTION
**No production change.** `ScFieldErrors` is correct as it stands — the investigation ends in "leave it", plus tests so the conclusion is checkable.

## The question, and why it dissolves

I had recorded `ScFieldErrors` as a **third, inconsistent** way of reading form state, alongside push and pull. It isn't. There are two *roles*:

- **Controls** declare inputs and let the `Field` directive push state in.
- **Containers** query downward with `contentChild(FormField)`, because the field lives on a descendant and injection only walks up.

`ScField` has always done the second, `ScPasswordProvider` does since #1519, and `ScFieldErrors` reads the result through `SC_FIELD`. That's one pattern used consistently, not an outlier.

Declaring `errors` as an input on `ScFieldErrors` would be **dead code**: it isn't a form control, nothing binds `[formField]` to it, so the `Field` directive would never populate it — the same trap the password toggle's `disabled` fell into.

## Tests

4 added (55 total), covering hidden-until-touched and message rendering, with the control both as a **direct child** of the field and **nested inside an input group**. The nested case is the one where a downward query could plausibly miss a control. It doesn't.

Worth flagging how that went: both cases initially failed, which looked like a real bug in the nesting. It was the test — `minLength` skips empty strings, so the field was simply valid. Logging `state.invalid()` showed `false` and settled it. Same shape of mistake as the radio probe earlier, where a synthetic `blur` didn't mark a field touched.

## Doc

`docs/form-control-contract.md`: last item closed, the table row reframed as the container pattern, and a "Controls versus containers" section added. Renamed `## TODO` to `## Decisions`, since everything in it is now resolved.

## Verification

55/55 pass. `nx lint` across `ui` and `showcase` — 10 warnings, matching baseline. `tsc --noEmit` exit 0; `validate-demo-code` 0 mismatches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)