### PR TITLE
fix(menubar,navigation-menu): align with shadcn nova

### DIFF
--- a/libs/ui/src/lib/components/menu-bar/menu-bar-item.ts
+++ b/libs/ui/src/lib/components/menu-bar/menu-bar-item.ts
@@ -71,7 +71,7 @@ export class ScMenuBarItem {
 
   protected readonly class = computed(() =>
     cn(
-      'flex items-center rounded-sm px-2 py-0.5 text-sm font-medium outline-hidden select-none cursor-default hover:bg-muted aria-expanded:bg-muted focus-visible:outline-2 focus-visible:outline-ring',
+      'flex items-center rounded-sm px-1.5 py-0.5 text-sm font-medium outline-hidden select-none cursor-default hover:bg-muted aria-expanded:bg-muted focus-visible:outline-2 focus-visible:outline-ring',
       this.classInput(),
     ),
   );

--- a/libs/ui/src/lib/components/menu-bar/menu-bar.ts
+++ b/libs/ui/src/lib/components/menu-bar/menu-bar.ts
@@ -17,7 +17,7 @@ export class ScMenuBar {
 
   protected readonly class = computed(() =>
     cn(
-      'flex h-8 items-center gap-0.5 rounded-lg border bg-background p-[3px]',
+      'flex h-8 items-center gap-0.5 rounded-lg border p-[3px]',
       this.classInput(),
     ),
   );

--- a/libs/ui/src/lib/components/navigation-menu/navigation-menu-link.ts
+++ b/libs/ui/src/lib/components/navigation-menu/navigation-menu-link.ts
@@ -15,13 +15,12 @@ export class ScNavigationMenuLink {
 
   protected readonly class = computed(() =>
     cn(
-      'data-[active=true]:focus:bg-accent data-[active=true]:hover:bg-accent data-[active=true]:bg-accent/50 data-[active=true]:text-accent-foreground',
-      'hover:bg-accent hover:text-accent-foreground',
-      'focus:bg-accent focus:text-accent-foreground',
+      'data-[active=true]:focus:bg-muted data-[active=true]:hover:bg-muted data-[active=true]:bg-muted/50',
+      'hover:bg-muted focus:bg-muted',
       'focus-visible:ring-ring/50',
       '[&_svg:not([class*="text-"])]:text-muted-foreground',
-      'flex flex-col gap-1 rounded-sm p-2 text-sm transition-all outline-none',
-      'focus-visible:ring-[3px] focus-visible:outline-1',
+      'flex items-center gap-2 rounded-lg p-2 text-sm transition-all outline-none',
+      'focus-visible:ring-3 focus-visible:outline-1',
       '[&_svg:not([class*="size-"])]:size-4',
       this.classInput(),
     ),

--- a/libs/ui/src/lib/components/navigation-menu/navigation-menu-list.ts
+++ b/libs/ui/src/lib/components/navigation-menu/navigation-menu-list.ts
@@ -12,7 +12,7 @@ export class ScNavigationMenuList {
 
   protected readonly class = computed(() =>
     cn(
-      'group flex flex-1 list-none items-center justify-center gap-1',
+      'group flex flex-1 list-none items-center justify-center gap-0',
       this.classInput(),
     ),
   );

--- a/libs/ui/src/lib/components/navigation-menu/navigation-menu-trigger.ts
+++ b/libs/ui/src/lib/components/navigation-menu/navigation-menu-trigger.ts
@@ -34,12 +34,11 @@ export class ScNavigationMenuTrigger {
 
   protected readonly class = computed(() =>
     cn(
-      'group inline-flex h-9 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium',
-      'hover:bg-accent hover:text-accent-foreground',
-      'focus:bg-accent focus:text-accent-foreground',
+      'group inline-flex w-max items-center justify-center rounded-lg px-2.5 py-1.5 text-sm font-medium',
+      'hover:bg-muted focus:bg-muted',
       'disabled:pointer-events-none disabled:opacity-50',
-      'data-[state=open]:hover:bg-accent data-[state=open]:text-accent-foreground data-[state=open]:focus:bg-accent data-[state=open]:bg-accent/50',
-      'focus-visible:ring-ring/50 outline-none transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1',
+      'data-[state=open]:hover:bg-muted data-[state=open]:focus:bg-muted data-[state=open]:bg-muted/50',
+      'focus-visible:ring-ring/50 outline-none transition-all focus-visible:ring-3 focus-visible:outline-1',
       '[&_svg]:pointer-events-none',
       this.classInput(),
     ),


### PR DESCRIPTION
Batch 6: `context-menu`, `menu`, `menubar`, `navigation-menu`.

`menu-separator` matches upstream exactly, and our context menu renders its popup through `ScMenu` — whose content and item were already aligned in #1512 — so neither needed changes.

## ⚠️ This one changes the showcase's own header

`navigation-menu` is still shaped like shadcn **v3**:

| | ours | upstream |
|---|---|---|
| list gap | `gap-1` | `gap-0` |
| trigger size | `h-9 px-4 py-2` | `px-2.5 py-1.5` |
| trigger radius | `rounded-md` | `rounded-lg` |
| trigger bg | `bg-background` | *(none)* |
| hover/focus/open | `bg-accent` | `bg-muted` |
| link | `rounded-sm`, `flex-col` | `rounded-lg`, `items-center gap-2` |

**Nav items get noticeably smaller** — `px-4 py-2` → `px-2.5 py-1.5` and the fixed `h-9` goes. `apps/showcase/src/app/components/navbar/navbar.ts` uses these triggers, so the docs site header shrinks too. That's the intended upstream look, but it's the most visible change in this run and worth eyeballing before merge.

The colour half is subtler: `--accent` and `--muted` are **identical in light mode** (`oklch(0.97 0 0)`), so it only shows in dark, where `--accent` is `0.371` against `--muted` `0.269`.

## menubar

Two small deltas: the bar carried a `bg-background` upstream doesn't set, and the trigger used `px-2` where upstream uses `px-1.5`. (`py-0.5` and upstream's `py-[2px]` are the same 2px, so that one's untouched.)

## Not in this batch

**`sidebar`** — 113 lines of upstream CSS, more than the rest of this batch combined. It deserves its own pass rather than being tacked on.

## Verification

`nx lint` across `ui` and `showcase` — 10 warnings, matching baseline. `tsc --noEmit` exit 0; `validate-demo-code` 0 mismatches; 55/55 tests. Nothing asserts computed classes, so the nav change needs a look in both themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)