### PR TITLE
fix(table,breadcrumb,sheet,toast,select): align with shadcn nova

### DIFF
--- a/libs/ui/src/lib/components/breadcrumb/breadcrumb-ellipsis.ts
+++ b/libs/ui/src/lib/components/breadcrumb/breadcrumb-ellipsis.ts
@@ -14,7 +14,7 @@ export class ScBreadcrumbEllipsis {
 
   protected readonly class = computed(() =>
     cn(
-      'flex size-9 items-center justify-center [&_svg]:size-4',
+      'flex size-5 items-center justify-center [&_svg]:size-4',
       this.classInput(),
     ),
   );

--- a/libs/ui/src/lib/components/breadcrumb/breadcrumb-item.ts
+++ b/libs/ui/src/lib/components/breadcrumb/breadcrumb-item.ts
@@ -11,6 +11,6 @@ export class ScBreadcrumbItem {
   readonly classInput = input<string>('', { alias: 'class' });
 
   protected readonly class = computed(() =>
-    cn('inline-flex items-center gap-1.5', this.classInput()),
+    cn('inline-flex items-center gap-1', this.classInput()),
   );
 }

--- a/libs/ui/src/lib/components/select/select-group.ts
+++ b/libs/ui/src/lib/components/select/select-group.ts
@@ -16,6 +16,6 @@ export class ScSelectGroup {
   readonly classInput = input<string>('', { alias: 'class' });
 
   protected readonly class = computed(() =>
-    cn('flex flex-col', this.classInput()),
+    cn('flex flex-col scroll-my-1 p-1', this.classInput()),
   );
 }

--- a/libs/ui/src/lib/components/sheet/sheet-title.ts
+++ b/libs/ui/src/lib/components/sheet/sheet-title.ts
@@ -14,6 +14,6 @@ export class ScSheetTitle {
   readonly classInput = input<string>('', { alias: 'class' });
 
   protected readonly class = computed(() =>
-    cn('text-lg font-semibold text-foreground', this.classInput()),
+    cn('text-base font-medium text-foreground', this.classInput()),
   );
 }

--- a/libs/ui/src/lib/components/table/table-cell.ts
+++ b/libs/ui/src/lib/components/table/table-cell.ts
@@ -11,6 +11,9 @@ export class ScTableCell {
   readonly classInput = input<string>('', { alias: 'class' });
 
   protected readonly class = computed(() =>
-    cn('p-4 align-middle [&:has([role=checkbox])]:pe-0', this.classInput()),
+    cn(
+      'p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pe-0',
+      this.classInput(),
+    ),
   );
 }

--- a/libs/ui/src/lib/components/table/table-header-cell.ts
+++ b/libs/ui/src/lib/components/table/table-header-cell.ts
@@ -12,7 +12,7 @@ export class ScTableHeaderCell {
 
   protected readonly class = computed(() =>
     cn(
-      'h-12 px-4 text-start align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pe-0',
+      'text-foreground h-10 px-2 text-start align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pe-0',
       this.classInput(),
     ),
   );

--- a/libs/ui/src/lib/components/toast/toast.ts
+++ b/libs/ui/src/lib/components/toast/toast.ts
@@ -36,7 +36,7 @@ export class ScToast {
 
   protected readonly class = computed(() =>
     cn(
-      'group pointer-events-auto relative flex w-full items-center justify-between gap-4 overflow-hidden rounded-md border p-4 pe-6 shadow-lg transition-all',
+      'group pointer-events-auto relative flex w-full items-center justify-between gap-4 overflow-hidden rounded-2xl border p-4 pe-6 shadow-lg transition-all',
       'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full',
       this.position().startsWith('bottom')
         ? 'data-[state=open]:slide-in-from-bottom-full'


### PR DESCRIPTION
Batch 7. **Sidebar was the headline and needs nothing** — all 28 of its upstream classes already match.

Two looked like gaps and weren't: the skeleton's icon/text rules are inline in its template rather than separate files, and the sub-button's `data-[size=*]` text sizing is done in TypeScript with the host still setting `data-size`. That's the largest component in `nova.css` and it's clean.

So this sweeps the smaller components instead.

## Changes

| Component | Before | After |
|---|---|---|
| `table-head` | `h-12 px-4 text-muted-foreground` | `h-10 px-2 text-foreground` + `whitespace-nowrap` |
| `table-cell` | `p-4` | `p-2` + `whitespace-nowrap` |
| `breadcrumb-item` | `gap-1.5` | `gap-1` |
| `breadcrumb-ellipsis` | `size-9` | `size-5` |
| `sheet-title` | `text-lg font-semibold` | `text-base font-medium` |
| `toast` | `rounded-md` | `rounded-2xl` |
| `select-group` | — | `scroll-my-1 p-1` |

**The table changes are the visible ones**: every table gets denser, and header text goes from muted to full contrast.

## Not done

`sheet-header` and `sheet-footer` have no padding of their own, because `ScSheet` puts `p-6` on the container — upstream leaves the container bare and puts `p-4` on each part. Matching that means moving padding between three components at once, so it wants its own change rather than riding along here.

## A note on the tooling

The sweep that found these pairs upstream class names to our **file names**, which worked far better than the `data-slot` join I tried in batch 1 (150 classes matched, versus 17). But **it silently skips anything it can't pair up** — `cn-table-head` was skipped because our file is `table-header-cell.ts`, and those turned out to be the biggest gaps in this batch. I found them by hand afterwards. Anything with a name that diverges from upstream is still invisible to the automated pass.

## Verification

`nx lint` across `ui` and `showcase` — 10 warnings, matching baseline. `tsc --noEmit` exit 0; `validate-demo-code` 0 mismatches; 55/55 tests. Nothing asserts computed classes, so the table density change wants a look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)