### PR TITLE
fix(calendar): match upstream's container padding

### DIFF
--- a/libs/ui/src/lib/components/calendar/calendar.ts
+++ b/libs/ui/src/lib/components/calendar/calendar.ts
@@ -147,7 +147,7 @@ export class ScCalendar {
 
   protected readonly class = computed(() =>
     cn(
-      'flex flex-col gap-4 p-3',
+      'flex flex-col gap-4 p-2',
       this.numberOfMonths() > 1 ? 'w-auto' : 'w-[276px]',
       this.classInput(),
     ),


### PR DESCRIPTION
Batch 8: `calendar`, `command`, `combobox`, `slider`, `avatar`.

**Almost everything was already aligned**, so this is a one-line change: the calendar container used `p-3` where upstream uses `p-2`.

The value here is mostly in what the sweep flagged and why it isn't drift — recorded so it doesn't get re-investigated:

| Flagged | Verdict |
|---|---|
| `command` / `command-item` | **Aligned.** Both looked like gaps because my first reads were truncated — `data-selected:bg-muted` and the svg sizing are both present |
| calendar `--cell-size` / `--cell-radius` | **Inert here.** Ours is a custom implementation, not react-day-picker; nothing reads those variables |
| `slider data-vertical:min-h-40` | **N/A.** Ours is a native `input[type=range]` styled via webkit pseudo-elements |
| `avatar after:rounded-full` | **No-op.** Does nothing without an `after:content`, and we have no such pseudo-element |
| `combobox-item`, `combobox-item-indicator` | **Real, but not styling** — see below |

The `[class*=size-]` vs `[class*='size-']` flags throughout are a quoting difference, not a behavioural one — unquoted attribute values are valid where the value is a valid identifier.

## The one real deferral

`combobox-item` and `combobox-item-indicator` genuinely differ, but on **state conventions** rather than styling: `data-active` where upstream uses `data-highlighted`, and an indicator shown via `group-aria-selected` rather than positioned absolutely. Swapping the classes without changing the underlying attributes would break selection highlighting, so it needs its own change.

## Verification

`nx lint` across `ui` and `showcase` — 10 warnings, matching baseline. `tsc --noEmit` exit 0; `validate-demo-code` 0 mismatches; 55/55 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)