### PR TITLE
fix(checkbox,otp): align the parts whose names diverge from upstream

### DIFF
--- a/libs/ui/src/lib/components/checkbox/checkbox-visual.ts
+++ b/libs/ui/src/lib/components/checkbox/checkbox-visual.ts
@@ -20,9 +20,9 @@ import { SC_CHECKBOX_FIELD } from './checkbox-types';
   },
   template: `
     @if (checkbox.dataState() === 'indeterminate') {
-      <svg siMinusIcon class="size-4"></svg>
+      <svg siMinusIcon class="size-3.5"></svg>
     } @else if (checkbox.dataState() === 'checked') {
-      <svg siCheckIcon class="size-4"></svg>
+      <svg siCheckIcon class="size-3.5"></svg>
     }
   `,
   encapsulation: ViewEncapsulation.None,

--- a/libs/ui/src/lib/components/otp/otp-slot.ts
+++ b/libs/ui/src/lib/components/otp/otp-slot.ts
@@ -63,8 +63,8 @@ export class ScOtpSlot {
 
   protected readonly class = computed(() =>
     cn(
-      'relative flex h-10 w-10 items-center justify-center border-y border-e border-input text-sm transition-all first:rounded-s-md first:border-s last:rounded-e-md',
-      this.isActive() && 'z-10 ring-2 ring-ring ring-offset-background',
+      'relative flex h-10 w-10 items-center justify-center dark:bg-input/30 border-y border-e border-input text-sm transition-all outline-none first:rounded-s-md first:border-s last:rounded-e-md',
+      this.isActive() && 'z-10 border-ring ring-ring/50 ring-3',
       this.classInput(),
     ),
   );


### PR DESCRIPTION
Batch 9, aimed at the blind spot flagged in #1523: the automated sweep pairs upstream class names to our **file names** and silently skips anything it can't pair. **157 of 404** upstream classes fall in that gap — which is how `cn-table-head` nearly slipped through last time.

Most of those 157 are components we simply don't have (bubble, attachment, message, per-item menubar parts). This maps the ones we *do* have under a different name and checks them by hand.

## Two real findings

**`checkbox-visual`** rendered its check and minus icons at `size-4` inside a `size-4` box, so the mark touched the border on every side. Upstream's indicator is `size-3.5`.

**`otp-slot`** used the **pre-v4 focus ring** — `ring-2` with `ring-offset-background` — where upstream uses `border-ring` + `ring-ring/50` + `ring-3`. That's the same legacy ring already replaced on checkbox in #1511 and radio in #1514, so OTP was the last component still carrying it. It also lacked `dark:bg-input/30`, so an empty slot had no fill in dark mode.

## Matched and clean

`fieldset`, `legend`, `field-errors`, `empty-body`, `empty-media`, `pagination-list`, `hover-card`, `scroll-area-scrollbar`, `progress`, and `otp` itself.

## Deliberately unchanged

- **`separator`** vertical uses `self-stretch`, upstream `h-full`. Different techniques with different requirements — `self-stretch` needs a flex parent, `h-full` a sized one — and ours suits the toolbars it's used in.
- **OTP caret** omits `duration-1000`, so it blinks at the 1.25s `tw-animate-css` defines rather than upstream's 1s. I checked the animation is actually defined before dismissing this — it is, so the caret does blink.
- **No table container**, so tables can't scroll horizontally the way upstream's do. That's a missing component, not a class gap.

Two of my mappings were wrong and are excluded: `cn-progress-value` is the numeric label, not the bar, and `cn-item-content` isn't `item-title`.

## Verification

`nx lint` across `ui` and `showcase` — 10 warnings, matching baseline. `tsc --noEmit` exit 0; `validate-demo-code` 0 mismatches; 55/55 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)