### PR TITLE
fix(combobox): position the item indicator the way upstream does

### DIFF
--- a/libs/ui/src/lib/components/combobox/combobox-item-indicator.ts
+++ b/libs/ui/src/lib/components/combobox/combobox-item-indicator.ts
@@ -12,6 +12,9 @@ export class ScComboboxItemIndicator {
   readonly classInput = input<string>('', { alias: 'class' });
 
   protected readonly class = computed(() =>
-    cn('hidden size-4 shrink-0 group-aria-selected:block', this.classInput()),
+    cn(
+      'pointer-events-none absolute end-2 hidden size-4 shrink-0 group-aria-selected:block',
+      this.classInput(),
+    ),
   );
 }

--- a/libs/ui/src/lib/components/combobox/combobox-item.ts
+++ b/libs/ui/src/lib/components/combobox/combobox-item.ts
@@ -23,7 +23,8 @@ export class ScComboboxItem {
 
   protected readonly class = computed(() =>
     cn(
-      'group data-[active=true]:bg-accent data-[active=true]:text-accent-foreground aria-selected:text-primary flex cursor-pointer items-center rounded-sm px-2 py-1.5 text-sm outline-none',
+      'group data-[active=true]:bg-accent data-[active=true]:text-accent-foreground aria-selected:text-primary relative flex cursor-pointer items-center gap-2 rounded-md py-1 pe-8 ps-1.5 text-sm outline-none',
+      "[&_svg:not([class*='size-'])]:size-4",
       this.classInput(),
     ),
   );


### PR DESCRIPTION
The deferral from #1524. `combobox-item` and its indicator differed from upstream in two ways, and only one was worth acting on.

## Layout — fixed

Upstream reserves space at the inline end of the item (`pe-8`) and positions the indicator **absolutely** there. Ours laid the indicator out inline, so **selecting a row reflowed its label**.

| | before | after |
|---|---|---|
| item | `rounded-sm px-2 py-1.5` | `relative gap-2 rounded-md py-1 pe-8 ps-1.5` + svg sizing |
| indicator | `hidden … group-aria-selected:block` | `absolute end-2 hidden … group-aria-selected:block` |

## State naming — deliberately left alone

Upstream keys highlighting off `data-highlighted` where we use `data-active`, and marks selection with `data-selected` where we use `aria-selected`. Renaming those means changing what the combobox **writes to the DOM**, not just what it styles — and `aria-selected` is the more accessible of the two regardless. The classes now match; the attribute names stay ours.

## One correction while applying

Upstream's indicator is a `span` wrapping an icon, so it carries `flex items-center justify-center`. **Ours is the `<svg>` itself** — I checked the demos to confirm — where those classes do nothing. It keeps a `hidden`/`block` toggle instead of copying them across.

## Verification

`nx lint` across `ui` and `showcase` — 10 warnings, matching baseline. `tsc --noEmit` exit 0; `validate-demo-code` 0 mismatches; 55/55 tests. The indicator is a direct child of the item, so `absolute` resolves against the item's new `relative` — worth confirming visually on the combobox demo, since nothing asserts computed classes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)