### PR TITLE
fix(sheet): move padding from the container onto the header and footer

### DIFF
--- a/libs/ui/src/lib/components/sheet/sheet-footer.ts
+++ b/libs/ui/src/lib/components/sheet/sheet-footer.ts
@@ -12,7 +12,7 @@ export class ScSheetFooter {
 
   protected readonly class = computed(() =>
     cn(
-      'flex flex-col-reverse gap-2 sm:flex-row sm:justify-end',
+      'flex flex-col-reverse gap-2 p-4 sm:flex-row sm:justify-end',
       this.classInput(),
     ),
   );

--- a/libs/ui/src/lib/components/sheet/sheet-header.ts
+++ b/libs/ui/src/lib/components/sheet/sheet-header.ts
@@ -11,6 +11,9 @@ export class ScSheetHeader {
   readonly classInput = input<string>('', { alias: 'class' });
 
   protected readonly class = computed(() =>
-    cn('flex flex-col gap-2 text-center sm:text-start', this.classInput()),
+    cn(
+      'flex flex-col gap-0.5 p-4 text-center sm:text-start',
+      this.classInput(),
+    ),
   );
 }

--- a/libs/ui/src/lib/components/sheet/sheet.ts
+++ b/libs/ui/src/lib/components/sheet/sheet.ts
@@ -47,7 +47,7 @@ export class ScSheet {
 
   protected readonly class = computed(() =>
     cn(
-      'bg-popover text-popover-foreground fixed z-50 flex flex-col gap-4 p-6 shadow-lg duration-200 ease-in-out transition',
+      'bg-popover text-popover-foreground fixed z-50 flex flex-col gap-4 bg-clip-padding text-sm shadow-lg duration-200 ease-in-out transition',
       // Position based on side
       'data-[side=bottom]:inset-x-0 data-[side=bottom]:bottom-0 data-[side=bottom]:h-auto data-[side=bottom]:border-t',
       'data-[side=left]:inset-y-0 data-[side=left]:left-0 data-[side=left]:h-full data-[side=left]:w-3/4 data-[side=left]:border-r data-[side=left]:sm:max-w-sm',


### PR DESCRIPTION
The last class-level item, deferred from #1523 because it moves padding across three components rather than changing one value.

## The change

`ScSheet` put `p-6` on the container. Upstream leaves the container bare and pads each part:

| | before | after |
|---|---|---|
| `sheet` | `gap-4 p-6` | `gap-4` + `bg-clip-padding text-sm` |
| `sheet-header` | `gap-2` | `gap-0.5 p-4` |
| `sheet-footer` | `gap-2` | `gap-2 p-4` |

Matching upstream also picked up `bg-clip-padding` and `text-sm` on the content, which we lacked.

## What this means for consumers

Content **not** inside a header or footer now sits flush. That's how upstream behaves too — neither it nor we ship a sheet *body* part, so the middle region is the consumer's to pad. I checked our demos first: they only place a header and footer inside the sheet, so nothing in the repo changes shape beyond the intended 24px → 16px.

## Verified after the fact

Re-ran the comparison across the whole family: `header`, `footer`, `title`, `description`, `close` all match.

The content element still reports `data-[side=left]:left-0` as a gap. That's a **false positive** — it's the deliberate physical side-keying from #1506, where `side="left"` means literally left. The sweep's RTL normaliser rewrites `left-0` to `start-0` and can't know that one is intentional.

## Verification

`nx lint` across `ui` and `showcase` — 10 warnings, matching baseline. `tsc --noEmit` exit 0; `validate-demo-code` 0 mismatches; 55/55 tests.

## The comparison is now done

Eleven batches. What remains isn't class drift:

- **No table container** — tables can't scroll horizontally as upstream's do. A missing component.
- **Components we don't have** — bubble, attachment, marker, message, per-item menubar/dropdown parts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)