### PR TITLE
feat(table): add ScTableContainer for horizontal scrolling

### DIFF
--- a/apps/showcase/src/app/pages/docs/table/demos/basic-table-demo-container.ts
+++ b/apps/showcase/src/app/pages/docs/table/demos/basic-table-demo-container.ts
@@ -21,6 +21,7 @@ export default class BasicTableDemoContainer {
   readonly code = `import { Component, ViewEncapsulation } from '@angular/core';
 import {
   ScTable,
+  ScTableContainer,
   ScTableBody,
   ScTableCell,
   ScTableHeader,
@@ -32,6 +33,7 @@ import {
   selector: 'app-basic-table-demo',
   imports: [
     ScTable,
+    ScTableContainer,
     ScTableBody,
     ScTableCell,
     ScTableHeaderCell,
@@ -39,48 +41,50 @@ import {
     ScTableRow,
   ],
   template: \`
-    <table scTable class="w-full max-w-2xl">
-      <thead scTableHeader>
-        <tr scTableRow>
-          <th scTableHeaderCell class="w-[100px]">Invoice</th>
-          <th scTableHeaderCell>Status</th>
-          <th scTableHeaderCell>Method</th>
-          <th scTableHeaderCell class="text-right">Amount</th>
-        </tr>
-      </thead>
-      <tbody scTableBody>
-        <tr scTableRow>
-          <td scTableCell class="font-medium">INV001</td>
-          <td scTableCell>Paid</td>
-          <td scTableCell>Credit Card</td>
-          <td scTableCell class="text-right">$250.00</td>
-        </tr>
-        <tr scTableRow>
-          <td scTableCell class="font-medium">INV002</td>
-          <td scTableCell>Pending</td>
-          <td scTableCell>PayPal</td>
-          <td scTableCell class="text-right">$150.00</td>
-        </tr>
-        <tr scTableRow>
-          <td scTableCell class="font-medium">INV003</td>
-          <td scTableCell>Unpaid</td>
-          <td scTableCell>Bank Transfer</td>
-          <td scTableCell class="text-right">$350.00</td>
-        </tr>
-        <tr scTableRow>
-          <td scTableCell class="font-medium">INV004</td>
-          <td scTableCell>Paid</td>
-          <td scTableCell>Credit Card</td>
-          <td scTableCell class="text-right">$450.00</td>
-        </tr>
-        <tr scTableRow>
-          <td scTableCell class="font-medium">INV005</td>
-          <td scTableCell>Paid</td>
-          <td scTableCell>PayPal</td>
-          <td scTableCell class="text-right">$550.00</td>
-        </tr>
-      </tbody>
-    </table>
+    <div scTableContainer>
+      <table scTable class="w-full max-w-2xl">
+        <thead scTableHeader>
+          <tr scTableRow>
+            <th scTableHeaderCell class="w-[100px]">Invoice</th>
+            <th scTableHeaderCell>Status</th>
+            <th scTableHeaderCell>Method</th>
+            <th scTableHeaderCell class="text-right">Amount</th>
+          </tr>
+        </thead>
+        <tbody scTableBody>
+          <tr scTableRow>
+            <td scTableCell class="font-medium">INV001</td>
+            <td scTableCell>Paid</td>
+            <td scTableCell>Credit Card</td>
+            <td scTableCell class="text-right">$250.00</td>
+          </tr>
+          <tr scTableRow>
+            <td scTableCell class="font-medium">INV002</td>
+            <td scTableCell>Pending</td>
+            <td scTableCell>PayPal</td>
+            <td scTableCell class="text-right">$150.00</td>
+          </tr>
+          <tr scTableRow>
+            <td scTableCell class="font-medium">INV003</td>
+            <td scTableCell>Unpaid</td>
+            <td scTableCell>Bank Transfer</td>
+            <td scTableCell class="text-right">$350.00</td>
+          </tr>
+          <tr scTableRow>
+            <td scTableCell class="font-medium">INV004</td>
+            <td scTableCell>Paid</td>
+            <td scTableCell>Credit Card</td>
+            <td scTableCell class="text-right">$450.00</td>
+          </tr>
+          <tr scTableRow>
+            <td scTableCell class="font-medium">INV005</td>
+            <td scTableCell>Paid</td>
+            <td scTableCell>PayPal</td>
+            <td scTableCell class="text-right">$550.00</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
   \`,
   host: { class: 'flex w-full justify-center' },
   encapsulation: ViewEncapsulation.None,

--- a/apps/showcase/src/app/pages/docs/table/demos/basic-table-demo.ts
+++ b/apps/showcase/src/app/pages/docs/table/demos/basic-table-demo.ts
@@ -3,6 +3,7 @@ import {
   ScTable,
   ScTableBody,
   ScTableCell,
+  ScTableContainer,
   ScTableHeader,
   ScTableHeaderCell,
   ScTableRow,
@@ -12,6 +13,7 @@ import {
   selector: 'app-basic-table-demo',
   imports: [
     ScTable,
+    ScTableContainer,
     ScTableBody,
     ScTableCell,
     ScTableHeaderCell,
@@ -19,48 +21,50 @@ import {
     ScTableRow,
   ],
   template: `
-    <table scTable class="w-full max-w-2xl">
-      <thead scTableHeader>
-        <tr scTableRow>
-          <th scTableHeaderCell class="w-[100px]">Invoice</th>
-          <th scTableHeaderCell>Status</th>
-          <th scTableHeaderCell>Method</th>
-          <th scTableHeaderCell class="text-right">Amount</th>
-        </tr>
-      </thead>
-      <tbody scTableBody>
-        <tr scTableRow>
-          <td scTableCell class="font-medium">INV001</td>
-          <td scTableCell>Paid</td>
-          <td scTableCell>Credit Card</td>
-          <td scTableCell class="text-right">$250.00</td>
-        </tr>
-        <tr scTableRow>
-          <td scTableCell class="font-medium">INV002</td>
-          <td scTableCell>Pending</td>
-          <td scTableCell>PayPal</td>
-          <td scTableCell class="text-right">$150.00</td>
-        </tr>
-        <tr scTableRow>
-          <td scTableCell class="font-medium">INV003</td>
-          <td scTableCell>Unpaid</td>
-          <td scTableCell>Bank Transfer</td>
-          <td scTableCell class="text-right">$350.00</td>
-        </tr>
-        <tr scTableRow>
-          <td scTableCell class="font-medium">INV004</td>
-          <td scTableCell>Paid</td>
-          <td scTableCell>Credit Card</td>
-          <td scTableCell class="text-right">$450.00</td>
-        </tr>
-        <tr scTableRow>
-          <td scTableCell class="font-medium">INV005</td>
-          <td scTableCell>Paid</td>
-          <td scTableCell>PayPal</td>
-          <td scTableCell class="text-right">$550.00</td>
-        </tr>
-      </tbody>
-    </table>
+    <div scTableContainer>
+      <table scTable class="w-full max-w-2xl">
+        <thead scTableHeader>
+          <tr scTableRow>
+            <th scTableHeaderCell class="w-[100px]">Invoice</th>
+            <th scTableHeaderCell>Status</th>
+            <th scTableHeaderCell>Method</th>
+            <th scTableHeaderCell class="text-right">Amount</th>
+          </tr>
+        </thead>
+        <tbody scTableBody>
+          <tr scTableRow>
+            <td scTableCell class="font-medium">INV001</td>
+            <td scTableCell>Paid</td>
+            <td scTableCell>Credit Card</td>
+            <td scTableCell class="text-right">$250.00</td>
+          </tr>
+          <tr scTableRow>
+            <td scTableCell class="font-medium">INV002</td>
+            <td scTableCell>Pending</td>
+            <td scTableCell>PayPal</td>
+            <td scTableCell class="text-right">$150.00</td>
+          </tr>
+          <tr scTableRow>
+            <td scTableCell class="font-medium">INV003</td>
+            <td scTableCell>Unpaid</td>
+            <td scTableCell>Bank Transfer</td>
+            <td scTableCell class="text-right">$350.00</td>
+          </tr>
+          <tr scTableRow>
+            <td scTableCell class="font-medium">INV004</td>
+            <td scTableCell>Paid</td>
+            <td scTableCell>Credit Card</td>
+            <td scTableCell class="text-right">$450.00</td>
+          </tr>
+          <tr scTableRow>
+            <td scTableCell class="font-medium">INV005</td>
+            <td scTableCell>Paid</td>
+            <td scTableCell>PayPal</td>
+            <td scTableCell class="text-right">$550.00</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
   `,
   host: { class: 'flex w-full justify-center' },
   encapsulation: ViewEncapsulation.None,

--- a/apps/showcase/src/app/pages/docs/table/demos/caption-table-demo-container.ts
+++ b/apps/showcase/src/app/pages/docs/table/demos/caption-table-demo-container.ts
@@ -21,6 +21,7 @@ export default class CaptionTableDemoContainer {
   readonly code = `import { Component, ViewEncapsulation } from '@angular/core';
 import {
   ScTable,
+  ScTableContainer,
   ScTableBody,
   ScTableCaption,
   ScTableCell,
@@ -33,6 +34,7 @@ import {
   selector: 'app-caption-table-demo',
   imports: [
     ScTable,
+    ScTableContainer,
     ScTableBody,
     ScTableCaption,
     ScTableCell,
@@ -41,31 +43,33 @@ import {
     ScTableRow,
   ],
   template: \`
-    <table scTable class="w-full max-w-2xl">
-      <caption scTableCaption>A list of your recent invoices.</caption>
-      <thead scTableHeader>
-        <tr scTableRow>
-          <th scTableHeaderCell class="w-[100px]">Invoice</th>
-          <th scTableHeaderCell>Status</th>
-          <th scTableHeaderCell>Method</th>
-          <th scTableHeaderCell class="text-right">Amount</th>
-        </tr>
-      </thead>
-      <tbody scTableBody>
-        <tr scTableRow>
-          <td scTableCell class="font-medium">INV001</td>
-          <td scTableCell>Paid</td>
-          <td scTableCell>Credit Card</td>
-          <td scTableCell class="text-right">$250.00</td>
-        </tr>
-        <tr scTableRow>
-          <td scTableCell class="font-medium">INV002</td>
-          <td scTableCell>Pending</td>
-          <td scTableCell>PayPal</td>
-          <td scTableCell class="text-right">$150.00</td>
-        </tr>
-      </tbody>
-    </table>
+    <div scTableContainer>
+      <table scTable class="w-full max-w-2xl">
+        <caption scTableCaption>A list of your recent invoices.</caption>
+        <thead scTableHeader>
+          <tr scTableRow>
+            <th scTableHeaderCell class="w-[100px]">Invoice</th>
+            <th scTableHeaderCell>Status</th>
+            <th scTableHeaderCell>Method</th>
+            <th scTableHeaderCell class="text-right">Amount</th>
+          </tr>
+        </thead>
+        <tbody scTableBody>
+          <tr scTableRow>
+            <td scTableCell class="font-medium">INV001</td>
+            <td scTableCell>Paid</td>
+            <td scTableCell>Credit Card</td>
+            <td scTableCell class="text-right">$250.00</td>
+          </tr>
+          <tr scTableRow>
+            <td scTableCell class="font-medium">INV002</td>
+            <td scTableCell>Pending</td>
+            <td scTableCell>PayPal</td>
+            <td scTableCell class="text-right">$150.00</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
   \`,
   host: { class: 'flex w-full justify-center' },
   encapsulation: ViewEncapsulation.None,

--- a/apps/showcase/src/app/pages/docs/table/demos/caption-table-demo.ts
+++ b/apps/showcase/src/app/pages/docs/table/demos/caption-table-demo.ts
@@ -4,6 +4,7 @@ import {
   ScTableBody,
   ScTableCaption,
   ScTableCell,
+  ScTableContainer,
   ScTableHeader,
   ScTableHeaderCell,
   ScTableRow,
@@ -13,6 +14,7 @@ import {
   selector: 'app-caption-table-demo',
   imports: [
     ScTable,
+    ScTableContainer,
     ScTableBody,
     ScTableCaption,
     ScTableCell,
@@ -21,31 +23,33 @@ import {
     ScTableRow,
   ],
   template: `
-    <table scTable class="w-full max-w-2xl">
-      <caption scTableCaption>A list of your recent invoices.</caption>
-      <thead scTableHeader>
-        <tr scTableRow>
-          <th scTableHeaderCell class="w-[100px]">Invoice</th>
-          <th scTableHeaderCell>Status</th>
-          <th scTableHeaderCell>Method</th>
-          <th scTableHeaderCell class="text-right">Amount</th>
-        </tr>
-      </thead>
-      <tbody scTableBody>
-        <tr scTableRow>
-          <td scTableCell class="font-medium">INV001</td>
-          <td scTableCell>Paid</td>
-          <td scTableCell>Credit Card</td>
-          <td scTableCell class="text-right">$250.00</td>
-        </tr>
-        <tr scTableRow>
-          <td scTableCell class="font-medium">INV002</td>
-          <td scTableCell>Pending</td>
-          <td scTableCell>PayPal</td>
-          <td scTableCell class="text-right">$150.00</td>
-        </tr>
-      </tbody>
-    </table>
+    <div scTableContainer>
+      <table scTable class="w-full max-w-2xl">
+        <caption scTableCaption>A list of your recent invoices.</caption>
+        <thead scTableHeader>
+          <tr scTableRow>
+            <th scTableHeaderCell class="w-[100px]">Invoice</th>
+            <th scTableHeaderCell>Status</th>
+            <th scTableHeaderCell>Method</th>
+            <th scTableHeaderCell class="text-right">Amount</th>
+          </tr>
+        </thead>
+        <tbody scTableBody>
+          <tr scTableRow>
+            <td scTableCell class="font-medium">INV001</td>
+            <td scTableCell>Paid</td>
+            <td scTableCell>Credit Card</td>
+            <td scTableCell class="text-right">$250.00</td>
+          </tr>
+          <tr scTableRow>
+            <td scTableCell class="font-medium">INV002</td>
+            <td scTableCell>Pending</td>
+            <td scTableCell>PayPal</td>
+            <td scTableCell class="text-right">$150.00</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
   `,
   host: { class: 'flex w-full justify-center' },
   encapsulation: ViewEncapsulation.None,

--- a/apps/showcase/src/app/pages/docs/table/demos/footer-table-demo-container.ts
+++ b/apps/showcase/src/app/pages/docs/table/demos/footer-table-demo-container.ts
@@ -21,6 +21,7 @@ export default class FooterTableDemoContainer {
   readonly code = `import { Component, ViewEncapsulation } from '@angular/core';
 import {
   ScTable,
+  ScTableContainer,
   ScTableBody,
   ScTableCell,
   ScTableFooter,
@@ -33,6 +34,7 @@ import {
   selector: 'app-footer-table-demo',
   imports: [
     ScTable,
+    ScTableContainer,
     ScTableBody,
     ScTableCell,
     ScTableFooter,
@@ -41,42 +43,44 @@ import {
     ScTableRow,
   ],
   template: \`
-    <table scTable class="w-full max-w-2xl">
-      <thead scTableHeader>
-        <tr scTableRow>
-          <th scTableHeaderCell class="w-[100px]">Invoice</th>
-          <th scTableHeaderCell>Status</th>
-          <th scTableHeaderCell>Method</th>
-          <th scTableHeaderCell class="text-right">Amount</th>
-        </tr>
-      </thead>
-      <tbody scTableBody>
-        <tr scTableRow>
-          <td scTableCell class="font-medium">INV001</td>
-          <td scTableCell>Paid</td>
-          <td scTableCell>Credit Card</td>
-          <td scTableCell class="text-right">$250.00</td>
-        </tr>
-        <tr scTableRow>
-          <td scTableCell class="font-medium">INV002</td>
-          <td scTableCell>Pending</td>
-          <td scTableCell>PayPal</td>
-          <td scTableCell class="text-right">$150.00</td>
-        </tr>
-        <tr scTableRow>
-          <td scTableCell class="font-medium">INV003</td>
-          <td scTableCell>Paid</td>
-          <td scTableCell>Bank Transfer</td>
-          <td scTableCell class="text-right">$350.00</td>
-        </tr>
-      </tbody>
-      <tfoot scTableFooter>
-        <tr scTableRow>
-          <td scTableCell colspan="3">Total</td>
-          <td scTableCell class="text-right">$750.00</td>
-        </tr>
-      </tfoot>
-    </table>
+    <div scTableContainer>
+      <table scTable class="w-full max-w-2xl">
+        <thead scTableHeader>
+          <tr scTableRow>
+            <th scTableHeaderCell class="w-[100px]">Invoice</th>
+            <th scTableHeaderCell>Status</th>
+            <th scTableHeaderCell>Method</th>
+            <th scTableHeaderCell class="text-right">Amount</th>
+          </tr>
+        </thead>
+        <tbody scTableBody>
+          <tr scTableRow>
+            <td scTableCell class="font-medium">INV001</td>
+            <td scTableCell>Paid</td>
+            <td scTableCell>Credit Card</td>
+            <td scTableCell class="text-right">$250.00</td>
+          </tr>
+          <tr scTableRow>
+            <td scTableCell class="font-medium">INV002</td>
+            <td scTableCell>Pending</td>
+            <td scTableCell>PayPal</td>
+            <td scTableCell class="text-right">$150.00</td>
+          </tr>
+          <tr scTableRow>
+            <td scTableCell class="font-medium">INV003</td>
+            <td scTableCell>Paid</td>
+            <td scTableCell>Bank Transfer</td>
+            <td scTableCell class="text-right">$350.00</td>
+          </tr>
+        </tbody>
+        <tfoot scTableFooter>
+          <tr scTableRow>
+            <td scTableCell colspan="3">Total</td>
+            <td scTableCell class="text-right">$750.00</td>
+          </tr>
+        </tfoot>
+      </table>
+    </div>
   \`,
   host: { class: 'flex w-full justify-center' },
   encapsulation: ViewEncapsulation.None,

--- a/apps/showcase/src/app/pages/docs/table/demos/footer-table-demo.ts
+++ b/apps/showcase/src/app/pages/docs/table/demos/footer-table-demo.ts
@@ -3,6 +3,7 @@ import {
   ScTable,
   ScTableBody,
   ScTableCell,
+  ScTableContainer,
   ScTableFooter,
   ScTableHeader,
   ScTableHeaderCell,
@@ -13,6 +14,7 @@ import {
   selector: 'app-footer-table-demo',
   imports: [
     ScTable,
+    ScTableContainer,
     ScTableBody,
     ScTableCell,
     ScTableFooter,
@@ -21,42 +23,44 @@ import {
     ScTableRow,
   ],
   template: `
-    <table scTable class="w-full max-w-2xl">
-      <thead scTableHeader>
-        <tr scTableRow>
-          <th scTableHeaderCell class="w-[100px]">Invoice</th>
-          <th scTableHeaderCell>Status</th>
-          <th scTableHeaderCell>Method</th>
-          <th scTableHeaderCell class="text-right">Amount</th>
-        </tr>
-      </thead>
-      <tbody scTableBody>
-        <tr scTableRow>
-          <td scTableCell class="font-medium">INV001</td>
-          <td scTableCell>Paid</td>
-          <td scTableCell>Credit Card</td>
-          <td scTableCell class="text-right">$250.00</td>
-        </tr>
-        <tr scTableRow>
-          <td scTableCell class="font-medium">INV002</td>
-          <td scTableCell>Pending</td>
-          <td scTableCell>PayPal</td>
-          <td scTableCell class="text-right">$150.00</td>
-        </tr>
-        <tr scTableRow>
-          <td scTableCell class="font-medium">INV003</td>
-          <td scTableCell>Paid</td>
-          <td scTableCell>Bank Transfer</td>
-          <td scTableCell class="text-right">$350.00</td>
-        </tr>
-      </tbody>
-      <tfoot scTableFooter>
-        <tr scTableRow>
-          <td scTableCell colspan="3">Total</td>
-          <td scTableCell class="text-right">$750.00</td>
-        </tr>
-      </tfoot>
-    </table>
+    <div scTableContainer>
+      <table scTable class="w-full max-w-2xl">
+        <thead scTableHeader>
+          <tr scTableRow>
+            <th scTableHeaderCell class="w-[100px]">Invoice</th>
+            <th scTableHeaderCell>Status</th>
+            <th scTableHeaderCell>Method</th>
+            <th scTableHeaderCell class="text-right">Amount</th>
+          </tr>
+        </thead>
+        <tbody scTableBody>
+          <tr scTableRow>
+            <td scTableCell class="font-medium">INV001</td>
+            <td scTableCell>Paid</td>
+            <td scTableCell>Credit Card</td>
+            <td scTableCell class="text-right">$250.00</td>
+          </tr>
+          <tr scTableRow>
+            <td scTableCell class="font-medium">INV002</td>
+            <td scTableCell>Pending</td>
+            <td scTableCell>PayPal</td>
+            <td scTableCell class="text-right">$150.00</td>
+          </tr>
+          <tr scTableRow>
+            <td scTableCell class="font-medium">INV003</td>
+            <td scTableCell>Paid</td>
+            <td scTableCell>Bank Transfer</td>
+            <td scTableCell class="text-right">$350.00</td>
+          </tr>
+        </tbody>
+        <tfoot scTableFooter>
+          <tr scTableRow>
+            <td scTableCell colspan="3">Total</td>
+            <td scTableCell class="text-right">$750.00</td>
+          </tr>
+        </tfoot>
+      </table>
+    </div>
   `,
   host: { class: 'flex w-full justify-center' },
   encapsulation: ViewEncapsulation.None,

--- a/apps/showcase/src/app/pages/docs/table/demos/table-usage-demo-container.ts
+++ b/apps/showcase/src/app/pages/docs/table/demos/table-usage-demo-container.ts
@@ -60,6 +60,7 @@ export class TableUsageDemoContainer {
   readonly code = `import { Component, ViewEncapsulation } from '@angular/core';
 import {
   ScTable,
+  ScTableContainer,
   ScTableBody,
   ScTableCaption,
   ScTableCell,
@@ -73,6 +74,7 @@ import {
   selector: 'app-table-usage-demo',
   imports: [
     ScTable,
+    ScTableContainer,
     ScTableBody,
     ScTableCaption,
     ScTableCell,
@@ -82,29 +84,31 @@ import {
     ScTableRow,
   ],
   template: \`
-    <table scTable>
-      <caption scTableCaption>A list of your recent invoices.</caption>
-      <thead scTableHeader>
-        <tr scTableRow>
-          <th scTableHeaderCell>Invoice</th>
-          <th scTableHeaderCell>Status</th>
-          <th scTableHeaderCell class="text-right">Amount</th>
-        </tr>
-      </thead>
-      <tbody scTableBody>
-        <tr scTableRow>
-          <td scTableCell>INV001</td>
-          <td scTableCell>Paid</td>
-          <td scTableCell class="text-right">$250.00</td>
-        </tr>
-      </tbody>
-      <tfoot scTableFooter>
-        <tr scTableRow>
-          <td scTableCell colspan="2">Total</td>
-          <td scTableCell class="text-right">$250.00</td>
-        </tr>
-      </tfoot>
-    </table>
+    <div scTableContainer>
+      <table scTable>
+        <caption scTableCaption>A list of your recent invoices.</caption>
+        <thead scTableHeader>
+          <tr scTableRow>
+            <th scTableHeaderCell>Invoice</th>
+            <th scTableHeaderCell>Status</th>
+            <th scTableHeaderCell class="text-right">Amount</th>
+          </tr>
+        </thead>
+        <tbody scTableBody>
+          <tr scTableRow>
+            <td scTableCell>INV001</td>
+            <td scTableCell>Paid</td>
+            <td scTableCell class="text-right">$250.00</td>
+          </tr>
+        </tbody>
+        <tfoot scTableFooter>
+          <tr scTableRow>
+            <td scTableCell colspan="2">Total</td>
+            <td scTableCell class="text-right">$250.00</td>
+          </tr>
+        </tfoot>
+      </table>
+    </div>
   \`,
   host: { class: 'flex w-full justify-center' },
   encapsulation: ViewEncapsulation.None,

--- a/apps/showcase/src/app/pages/docs/table/demos/table-usage-demo.ts
+++ b/apps/showcase/src/app/pages/docs/table/demos/table-usage-demo.ts
@@ -4,6 +4,7 @@ import {
   ScTableBody,
   ScTableCaption,
   ScTableCell,
+  ScTableContainer,
   ScTableFooter,
   ScTableHeader,
   ScTableHeaderCell,
@@ -14,6 +15,7 @@ import {
   selector: 'app-table-usage-demo',
   imports: [
     ScTable,
+    ScTableContainer,
     ScTableBody,
     ScTableCaption,
     ScTableCell,
@@ -23,29 +25,31 @@ import {
     ScTableRow,
   ],
   template: `
-    <table scTable>
-      <caption scTableCaption>A list of your recent invoices.</caption>
-      <thead scTableHeader>
-        <tr scTableRow>
-          <th scTableHeaderCell>Invoice</th>
-          <th scTableHeaderCell>Status</th>
-          <th scTableHeaderCell class="text-right">Amount</th>
-        </tr>
-      </thead>
-      <tbody scTableBody>
-        <tr scTableRow>
-          <td scTableCell>INV001</td>
-          <td scTableCell>Paid</td>
-          <td scTableCell class="text-right">$250.00</td>
-        </tr>
-      </tbody>
-      <tfoot scTableFooter>
-        <tr scTableRow>
-          <td scTableCell colspan="2">Total</td>
-          <td scTableCell class="text-right">$250.00</td>
-        </tr>
-      </tfoot>
-    </table>
+    <div scTableContainer>
+      <table scTable>
+        <caption scTableCaption>A list of your recent invoices.</caption>
+        <thead scTableHeader>
+          <tr scTableRow>
+            <th scTableHeaderCell>Invoice</th>
+            <th scTableHeaderCell>Status</th>
+            <th scTableHeaderCell class="text-right">Amount</th>
+          </tr>
+        </thead>
+        <tbody scTableBody>
+          <tr scTableRow>
+            <td scTableCell>INV001</td>
+            <td scTableCell>Paid</td>
+            <td scTableCell class="text-right">$250.00</td>
+          </tr>
+        </tbody>
+        <tfoot scTableFooter>
+          <tr scTableRow>
+            <td scTableCell colspan="2">Total</td>
+            <td scTableCell class="text-right">$250.00</td>
+          </tr>
+        </tfoot>
+      </table>
+    </div>
   `,
   host: { class: 'flex w-full justify-center' },
   encapsulation: ViewEncapsulation.None,

--- a/apps/showcase/src/app/pages/docs/table/demos/users-table-demo-container.ts
+++ b/apps/showcase/src/app/pages/docs/table/demos/users-table-demo-container.ts
@@ -21,6 +21,7 @@ export default class UsersTableDemoContainer {
   readonly code = `import { Component, ViewEncapsulation } from '@angular/core';
 import {
   ScTable,
+  ScTableContainer,
   ScTableBody,
   ScTableCell,
   ScTableHeader,
@@ -32,6 +33,7 @@ import {
   selector: 'app-users-table-demo',
   imports: [
     ScTable,
+    ScTableContainer,
     ScTableBody,
     ScTableCell,
     ScTableHeaderCell,
@@ -40,81 +42,83 @@ import {
   ],
   template: \`
     <div class="w-full max-w-2xl rounded-md border">
-      <table scTable>
-        <thead scTableHeader>
-          <tr scTableRow>
-            <th scTableHeaderCell>Name</th>
-            <th scTableHeaderCell>Email</th>
-            <th scTableHeaderCell>Role</th>
-            <th scTableHeaderCell class="text-right">Actions</th>
-          </tr>
-        </thead>
-        <tbody scTableBody>
-          <tr scTableRow>
-            <td scTableCell>
-              <div class="font-medium">John Doe</div>
-              <div class="text-muted-foreground text-sm">Engineer</div>
-            </td>
-            <td scTableCell>john&#64;example.com</td>
-            <td scTableCell>
-              <span
-                class="inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold"
-              >
-                Admin
-              </span>
-            </td>
-            <td scTableCell class="text-right">
-              <button
-                class="text-muted-foreground hover:text-foreground text-sm"
-              >
-                Edit
-              </button>
-            </td>
-          </tr>
-          <tr scTableRow>
-            <td scTableCell>
-              <div class="font-medium">Jane Smith</div>
-              <div class="text-muted-foreground text-sm">Designer</div>
-            </td>
-            <td scTableCell>jane&#64;example.com</td>
-            <td scTableCell>
-              <span
-                class="inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold"
-              >
-                Member
-              </span>
-            </td>
-            <td scTableCell class="text-right">
-              <button
-                class="text-muted-foreground hover:text-foreground text-sm"
-              >
-                Edit
-              </button>
-            </td>
-          </tr>
-          <tr scTableRow>
-            <td scTableCell>
-              <div class="font-medium">Bob Johnson</div>
-              <div class="text-muted-foreground text-sm">Manager</div>
-            </td>
-            <td scTableCell>bob&#64;example.com</td>
-            <td scTableCell>
-              <span
-                class="inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold"
-              >
-                Owner
-              </span>
-            </td>
-            <td scTableCell class="text-right">
-              <button
-                class="text-muted-foreground hover:text-foreground text-sm"
-              >
-                Edit
-              </button>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+      <div scTableContainer>
+        <table scTable>
+          <thead scTableHeader>
+            <tr scTableRow>
+              <th scTableHeaderCell>Name</th>
+              <th scTableHeaderCell>Email</th>
+              <th scTableHeaderCell>Role</th>
+              <th scTableHeaderCell class="text-right">Actions</th>
+            </tr>
+          </thead>
+          <tbody scTableBody>
+            <tr scTableRow>
+              <td scTableCell>
+                <div class="font-medium">John Doe</div>
+                <div class="text-muted-foreground text-sm">Engineer</div>
+              </td>
+              <td scTableCell>john&#64;example.com</td>
+              <td scTableCell>
+                <span
+                  class="inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold"
+                >
+                  Admin
+                </span>
+              </td>
+              <td scTableCell class="text-right">
+                <button
+                  class="text-muted-foreground hover:text-foreground text-sm"
+                >
+                  Edit
+                </button>
+              </td>
+            </tr>
+            <tr scTableRow>
+              <td scTableCell>
+                <div class="font-medium">Jane Smith</div>
+                <div class="text-muted-foreground text-sm">Designer</div>
+              </td>
+              <td scTableCell>jane&#64;example.com</td>
+              <td scTableCell>
+                <span
+                  class="inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold"
+                >
+                  Member
+                </span>
+              </td>
+              <td scTableCell class="text-right">
+                <button
+                  class="text-muted-foreground hover:text-foreground text-sm"
+                >
+                  Edit
+                </button>
+              </td>
+            </tr>
+            <tr scTableRow>
+              <td scTableCell>
+                <div class="font-medium">Bob Johnson</div>
+                <div class="text-muted-foreground text-sm">Manager</div>
+              </td>
+              <td scTableCell>bob&#64;example.com</td>
+              <td scTableCell>
+                <span
+                  class="inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold"
+                >
+                  Owner
+                </span>
+              </td>
+              <td scTableCell class="text-right">
+                <button
+                  class="text-muted-foreground hover:text-foreground text-sm"
+                >
+                  Edit
+                </button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
     </div>
   \`,
   host: { class: 'flex w-full justify-center' },

--- a/apps/showcase/src/app/pages/docs/table/demos/users-table-demo.ts
+++ b/apps/showcase/src/app/pages/docs/table/demos/users-table-demo.ts
@@ -3,6 +3,7 @@ import {
   ScTable,
   ScTableBody,
   ScTableCell,
+  ScTableContainer,
   ScTableHeader,
   ScTableHeaderCell,
   ScTableRow,
@@ -12,6 +13,7 @@ import {
   selector: 'app-users-table-demo',
   imports: [
     ScTable,
+    ScTableContainer,
     ScTableBody,
     ScTableCell,
     ScTableHeaderCell,
@@ -20,81 +22,83 @@ import {
   ],
   template: `
     <div class="w-full max-w-2xl rounded-md border">
-      <table scTable>
-        <thead scTableHeader>
-          <tr scTableRow>
-            <th scTableHeaderCell>Name</th>
-            <th scTableHeaderCell>Email</th>
-            <th scTableHeaderCell>Role</th>
-            <th scTableHeaderCell class="text-right">Actions</th>
-          </tr>
-        </thead>
-        <tbody scTableBody>
-          <tr scTableRow>
-            <td scTableCell>
-              <div class="font-medium">John Doe</div>
-              <div class="text-muted-foreground text-sm">Engineer</div>
-            </td>
-            <td scTableCell>john&#64;example.com</td>
-            <td scTableCell>
-              <span
-                class="inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold"
-              >
-                Admin
-              </span>
-            </td>
-            <td scTableCell class="text-right">
-              <button
-                class="text-muted-foreground hover:text-foreground text-sm"
-              >
-                Edit
-              </button>
-            </td>
-          </tr>
-          <tr scTableRow>
-            <td scTableCell>
-              <div class="font-medium">Jane Smith</div>
-              <div class="text-muted-foreground text-sm">Designer</div>
-            </td>
-            <td scTableCell>jane&#64;example.com</td>
-            <td scTableCell>
-              <span
-                class="inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold"
-              >
-                Member
-              </span>
-            </td>
-            <td scTableCell class="text-right">
-              <button
-                class="text-muted-foreground hover:text-foreground text-sm"
-              >
-                Edit
-              </button>
-            </td>
-          </tr>
-          <tr scTableRow>
-            <td scTableCell>
-              <div class="font-medium">Bob Johnson</div>
-              <div class="text-muted-foreground text-sm">Manager</div>
-            </td>
-            <td scTableCell>bob&#64;example.com</td>
-            <td scTableCell>
-              <span
-                class="inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold"
-              >
-                Owner
-              </span>
-            </td>
-            <td scTableCell class="text-right">
-              <button
-                class="text-muted-foreground hover:text-foreground text-sm"
-              >
-                Edit
-              </button>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+      <div scTableContainer>
+        <table scTable>
+          <thead scTableHeader>
+            <tr scTableRow>
+              <th scTableHeaderCell>Name</th>
+              <th scTableHeaderCell>Email</th>
+              <th scTableHeaderCell>Role</th>
+              <th scTableHeaderCell class="text-right">Actions</th>
+            </tr>
+          </thead>
+          <tbody scTableBody>
+            <tr scTableRow>
+              <td scTableCell>
+                <div class="font-medium">John Doe</div>
+                <div class="text-muted-foreground text-sm">Engineer</div>
+              </td>
+              <td scTableCell>john&#64;example.com</td>
+              <td scTableCell>
+                <span
+                  class="inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold"
+                >
+                  Admin
+                </span>
+              </td>
+              <td scTableCell class="text-right">
+                <button
+                  class="text-muted-foreground hover:text-foreground text-sm"
+                >
+                  Edit
+                </button>
+              </td>
+            </tr>
+            <tr scTableRow>
+              <td scTableCell>
+                <div class="font-medium">Jane Smith</div>
+                <div class="text-muted-foreground text-sm">Designer</div>
+              </td>
+              <td scTableCell>jane&#64;example.com</td>
+              <td scTableCell>
+                <span
+                  class="inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold"
+                >
+                  Member
+                </span>
+              </td>
+              <td scTableCell class="text-right">
+                <button
+                  class="text-muted-foreground hover:text-foreground text-sm"
+                >
+                  Edit
+                </button>
+              </td>
+            </tr>
+            <tr scTableRow>
+              <td scTableCell>
+                <div class="font-medium">Bob Johnson</div>
+                <div class="text-muted-foreground text-sm">Manager</div>
+              </td>
+              <td scTableCell>bob&#64;example.com</td>
+              <td scTableCell>
+                <span
+                  class="inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold"
+                >
+                  Owner
+                </span>
+              </td>
+              <td scTableCell class="text-right">
+                <button
+                  class="text-muted-foreground hover:text-foreground text-sm"
+                >
+                  Edit
+                </button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
     </div>
   `,
   host: { class: 'flex w-full justify-center' },

--- a/libs/ui/src/lib/components/table/README.md
+++ b/libs/ui/src/lib/components/table/README.md
@@ -5,33 +5,35 @@ A set of directives for building accessible, styled data tables using native HTM
 ## Usage
 
 ```typescript
-import { ScTable, ScTableBody, ScTableCaption, ScTableCell, ScTableFooter, ScTableHeader, ScTableHeaderCell, ScTableRow } from '@semantic-components/ui';
+import { ScTable, ScTableBody, ScTableCaption, ScTableCell, ScTableContainer, ScTableFooter, ScTableHeader, ScTableHeaderCell, ScTableRow } from '@semantic-components/ui';
 ```
 
 ```html
-<table scTable>
-  <caption scTableCaption>A list of recent invoices.</caption>
-  <thead scTableHeader>
-    <tr scTableRow>
-      <th scTableHeaderCell>Invoice</th>
-      <th scTableHeaderCell>Status</th>
-      <th scTableHeaderCell>Amount</th>
-    </tr>
-  </thead>
-  <tbody scTableBody>
-    <tr scTableRow>
-      <td scTableCell>INV-001</td>
-      <td scTableCell>Paid</td>
-      <td scTableCell>$250.00</td>
-    </tr>
-  </tbody>
-  <tfoot scTableFooter>
-    <tr scTableRow>
-      <td scTableCell colspan="2">Total</td>
-      <td scTableCell>$250.00</td>
-    </tr>
-  </tfoot>
-</table>
+<div scTableContainer>
+  <table scTable>
+    <caption scTableCaption>A list of recent invoices.</caption>
+    <thead scTableHeader>
+      <tr scTableRow>
+        <th scTableHeaderCell>Invoice</th>
+        <th scTableHeaderCell>Status</th>
+        <th scTableHeaderCell>Amount</th>
+      </tr>
+    </thead>
+    <tbody scTableBody>
+      <tr scTableRow>
+        <td scTableCell>INV-001</td>
+        <td scTableCell>Paid</td>
+        <td scTableCell>$250.00</td>
+      </tr>
+    </tbody>
+    <tfoot scTableFooter>
+      <tr scTableRow>
+        <td scTableCell colspan="2">Total</td>
+        <td scTableCell>$250.00</td>
+      </tr>
+    </tfoot>
+  </table>
+</div>
 ```
 
 ## Components
@@ -44,6 +46,15 @@ All directives accept a `class` input for merging additional CSS classes via the
 | --------------- | ------------------------------- |
 | Selector        | `table[scTable]`                |
 | Default classes | `w-full caption-bottom text-sm` |
+
+### ScTableContainer
+
+| Property        | Details                           |
+| --------------- | --------------------------------- |
+| Selector        | `div[scTableContainer]`           |
+| Default classes | `relative w-full overflow-x-auto` |
+
+Wraps the table so it scrolls horizontally rather than widening its parent.
 
 ### ScTableHeader
 

--- a/libs/ui/src/lib/components/table/index.ts
+++ b/libs/ui/src/lib/components/table/index.ts
@@ -1,4 +1,5 @@
 export * from './table';
+export * from './table-container';
 export * from './table-header';
 export * from './table-body';
 export * from './table-footer';

--- a/libs/ui/src/lib/components/table/table-container.ts
+++ b/libs/ui/src/lib/components/table/table-container.ts
@@ -1,0 +1,23 @@
+import { Directive, computed, input } from '@angular/core';
+import { cn } from '../../utils';
+
+/**
+ * Wraps a table so it can scroll horizontally instead of forcing its parent
+ * wider. Upstream's Table renders this automatically; ScTable is an attribute
+ * directive on the `table` element and cannot introduce a wrapper, so it is
+ * applied by the consumer.
+ */
+@Directive({
+  selector: 'div[scTableContainer]',
+  host: {
+    'data-slot': 'table-container',
+    '[class]': 'class()',
+  },
+})
+export class ScTableContainer {
+  readonly classInput = input<string>('', { alias: 'class' });
+
+  protected readonly class = computed(() =>
+    cn('relative w-full overflow-x-auto', this.classInput()),
+  );
+}


### PR DESCRIPTION
The last item with real user impact from the shadcn comparison.

Upstream's `Table` renders a wrapping div with `relative w-full overflow-x-auto` around every table, so a table wider than its parent **scrolls** instead of forcing the page wide. We had no equivalent — wide tables pushed their container.

## Why it's a separate directive

`ScTable` is an attribute directive on the `table` element and can't introduce a wrapper of its own, so the consumer applies one:

```html
<div scTableContainer>
  <table scTable>…</table>
</div>
```

That's a deliberate difference from upstream, where the wrapper is automatic. It's the same trade-off the library already makes everywhere by decomposing into directives over native elements, and it leaves the `table` element untouched.

## Scope

- New `ScTableContainer`, exported from the table index
- All five table demos wrapped, container code regenerated with `sync-demo-code.mjs`
- Documented in the component README with its own entry alongside the other parts, and the usage snippet updated

## Verification

`nx lint` across `ui` and `showcase` — 10 warnings, matching baseline. `tsc --noEmit` exit 0; `validate-demo-code` 0 mismatches (5 updated, 523 already in sync); 55/55 tests.

## That completes the comparison

Twelve batches. Everything upstream styles that we also have is now aligned, apart from divergences recorded as deliberate — physical side-keying for `data-[side=…]` APIs, our decomposition, the darkened `--destructive` for AA contrast, and our own state attribute names.

What's left is components we simply don't have: bubble, attachment, marker, message, and the per-item menubar/dropdown parts. Those are features to decide on, not parity work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)