### PR TITLE
test(query-param): pin debounce behaviour across navigation

### DIFF
--- a/apps/showcase/src/app/query-param-state.spec.ts
+++ b/apps/showcase/src/app/query-param-state.spec.ts
@@ -111,3 +111,29 @@ describe('injectQueryParam', () => {
     expect(c.page.value()).toBe(3);
   });
 });
+
+@Component({ template: '' })
+class Debounced {
+  readonly q = injectQueryParam(
+    'q',
+    parseAsString.withDefault('').withOptions({ debounceMs: 300 }),
+  );
+  readonly router = inject(Router);
+}
+
+describe('debounce vs back navigation', () => {
+  it('does not resurrect a pending write after the URL changes', async () => {
+    const c = await mount(Debounced, '/?q=one');
+
+    // Type, then navigate before the debounce window closes.
+    c.q.set('typed');
+    await c.router.navigateByUrl('/?q=two');
+    TestBed.tick();
+
+    await new Promise((r) => setTimeout(r, 400));
+    await settle();
+
+    expect(c.router.url).toContain('q=two');
+    expect(c.q.value()).toBe('two');
+  });
+});


### PR DESCRIPTION
**No production change — the bug I recorded doesn't exist.**

After #1479 I noted a gap: *"a pending debounced write is lost when the user hits Back."* Testing it, the behaviour is correct.

## Why it's fine

`debounced()` tracks the shared `raw` signal rather than capturing a value. So a router update during the debounce window **replaces** the pending value instead of racing it:

1. User types → `raw = 'typed'`, timer starts
2. User navigates → the sync service sets `raw = 'two'` from the URL, and the timer restarts
3. Timer fires with `'two'`; the effect's equality guard sees it already matches the URL and writes nothing

The typed text is discarded, which is what navigating away should do.

## The test

Type into a debounced param, navigate before the window closes, assert the URL and the signal both settle on the navigated value.

**Confirmed it isn't vacuous** by breaking the mechanism it relies on — dropping the router subscription in `ScQueryParamSync` fails it, alongside the existing external-navigation test.

Worth admitting my first attempt at that check was a `void 0` edit that changed nothing and "passed", which proved exactly nothing. The second attempt was a real mutation.

## Still open on this utility

- **`debounceMs` defaults to 0.** Every keystroke then triggers a `replaceState`. Safari throws `SecurityError` past roughly 100 calls in 30s, which is why nuqs throttles to ~50ms regardless. A floor is worth considering, but it changes default behaviour.
- **`debounced()` is `@experimental` in Angular 22** while backing a stable public option.

## Verification

`nx lint` across `ui`, `ui-lab` and `showcase` — 42 warnings, matching baseline (this run includes `ui-lab`, hence the higher number than recent PRs). `tsc --noEmit` exit 0; 56/56 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)