### PR TITLE
feat(ui-lab): add Marker

### DIFF
--- a/apps/showcase/src/app/pages/docs/marker/demos/basic-marker-demo-container.ts
+++ b/apps/showcase/src/app/pages/docs/marker/demos/basic-marker-demo-container.ts
@@ -1,0 +1,52 @@
+import { Component, ViewEncapsulation } from '@angular/core';
+import { DemoContainer } from '../../../../components/demo-container/demo-container';
+import { BasicMarkerDemo } from './basic-marker-demo';
+
+@Component({
+  selector: 'app-basic-marker-demo-container',
+  imports: [DemoContainer, BasicMarkerDemo],
+  template: `
+    <app-demo-container
+      title="Basic"
+      demoUrl="/demos/marker/basic-marker-demo"
+      [code]="code"
+    >
+      <app-basic-marker-demo />
+    </app-demo-container>
+  `,
+  host: { class: 'block w-full' },
+  encapsulation: ViewEncapsulation.None,
+})
+export class BasicMarkerDemoContainer {
+  readonly code = `import { Component, ViewEncapsulation } from '@angular/core';
+import {
+  ScMarker,
+  ScMarkerContent,
+  ScMarkerIcon,
+} from '@semantic-components/ui-lab';
+import { SiInfoIcon } from '@semantic-icons/lucide-icons';
+
+@Component({
+  selector: 'app-basic-marker-demo',
+  imports: [ScMarker, ScMarkerIcon, ScMarkerContent, SiInfoIcon],
+  template: \`
+    <div class="w-full max-w-md space-y-4">
+      <div scMarker>
+        <span scMarkerIcon><svg siInfoIcon></svg></span>
+        <span scMarkerContent>Draft saved a moment ago</span>
+      </div>
+
+      <div scMarker variant="separator">
+        <span scMarkerContent>Today</span>
+      </div>
+
+      <div scMarker variant="border">
+        <span scMarkerContent>Unread messages</span>
+      </div>
+    </div>
+  \`,
+  host: { class: 'flex w-full justify-center' },
+  encapsulation: ViewEncapsulation.None,
+})
+export class BasicMarkerDemo {}`;
+}

--- a/apps/showcase/src/app/pages/docs/marker/demos/basic-marker-demo.ts
+++ b/apps/showcase/src/app/pages/docs/marker/demos/basic-marker-demo.ts
@@ -1,0 +1,31 @@
+import { Component, ViewEncapsulation } from '@angular/core';
+import {
+  ScMarker,
+  ScMarkerContent,
+  ScMarkerIcon,
+} from '@semantic-components/ui-lab';
+import { SiInfoIcon } from '@semantic-icons/lucide-icons';
+
+@Component({
+  selector: 'app-basic-marker-demo',
+  imports: [ScMarker, ScMarkerIcon, ScMarkerContent, SiInfoIcon],
+  template: `
+    <div class="w-full max-w-md space-y-4">
+      <div scMarker>
+        <span scMarkerIcon><svg siInfoIcon></svg></span>
+        <span scMarkerContent>Draft saved a moment ago</span>
+      </div>
+
+      <div scMarker variant="separator">
+        <span scMarkerContent>Today</span>
+      </div>
+
+      <div scMarker variant="border">
+        <span scMarkerContent>Unread messages</span>
+      </div>
+    </div>
+  `,
+  host: { class: 'flex w-full justify-center' },
+  encapsulation: ViewEncapsulation.None,
+})
+export class BasicMarkerDemo {}

--- a/apps/showcase/src/app/pages/docs/marker/marker-page.ts
+++ b/apps/showcase/src/app/pages/docs/marker/marker-page.ts
@@ -1,0 +1,29 @@
+import { Component, ViewEncapsulation } from '@angular/core';
+import { ScHeading } from '@semantic-components/ui';
+import { ComponentBadges } from '../../../components/component-badges/component-badges';
+import { TocHeading } from '../../../components/toc/toc-heading';
+import { BasicMarkerDemoContainer } from './demos/basic-marker-demo-container';
+
+@Component({
+  selector: 'app-marker-page',
+  imports: [BasicMarkerDemoContainer, TocHeading, ComponentBadges, ScHeading],
+  template: `
+    <div class="space-y-8">
+      <div class="space-y-2">
+        <h1 scHeading>Marker</h1>
+        <p class="text-muted-foreground">
+          Label a point in a list or feed — a date divider, an unread boundary,
+          or a short inline note.
+        </p>
+        <app-component-badges path="marker" />
+      </div>
+
+      <section class="space-y-8">
+        <h2 scHeading appToc>Examples</h2>
+        <app-basic-marker-demo-container />
+      </section>
+    </div>
+  `,
+  encapsulation: ViewEncapsulation.None,
+})
+export default class MarkerPage {}

--- a/apps/showcase/src/app/pages/docs/table/demos/basic-table-demo-container.ts
+++ b/apps/showcase/src/app/pages/docs/table/demos/basic-table-demo-container.ts
@@ -21,9 +21,9 @@ export default class BasicTableDemoContainer {
   readonly code = `import { Component, ViewEncapsulation } from '@angular/core';
 import {
   ScTable,
-  ScTableContainer,
   ScTableBody,
   ScTableCell,
+  ScTableContainer,
   ScTableHeader,
   ScTableHeaderCell,
   ScTableRow,

--- a/apps/showcase/src/app/pages/docs/table/demos/caption-table-demo-container.ts
+++ b/apps/showcase/src/app/pages/docs/table/demos/caption-table-demo-container.ts
@@ -21,10 +21,10 @@ export default class CaptionTableDemoContainer {
   readonly code = `import { Component, ViewEncapsulation } from '@angular/core';
 import {
   ScTable,
-  ScTableContainer,
   ScTableBody,
   ScTableCaption,
   ScTableCell,
+  ScTableContainer,
   ScTableHeader,
   ScTableHeaderCell,
   ScTableRow,

--- a/apps/showcase/src/app/pages/docs/table/demos/footer-table-demo-container.ts
+++ b/apps/showcase/src/app/pages/docs/table/demos/footer-table-demo-container.ts
@@ -21,9 +21,9 @@ export default class FooterTableDemoContainer {
   readonly code = `import { Component, ViewEncapsulation } from '@angular/core';
 import {
   ScTable,
-  ScTableContainer,
   ScTableBody,
   ScTableCell,
+  ScTableContainer,
   ScTableFooter,
   ScTableHeader,
   ScTableHeaderCell,

--- a/apps/showcase/src/app/pages/docs/table/demos/table-usage-demo-container.ts
+++ b/apps/showcase/src/app/pages/docs/table/demos/table-usage-demo-container.ts
@@ -60,10 +60,10 @@ export class TableUsageDemoContainer {
   readonly code = `import { Component, ViewEncapsulation } from '@angular/core';
 import {
   ScTable,
-  ScTableContainer,
   ScTableBody,
   ScTableCaption,
   ScTableCell,
+  ScTableContainer,
   ScTableFooter,
   ScTableHeader,
   ScTableHeaderCell,

--- a/apps/showcase/src/app/pages/docs/table/demos/users-table-demo-container.ts
+++ b/apps/showcase/src/app/pages/docs/table/demos/users-table-demo-container.ts
@@ -21,9 +21,9 @@ export default class UsersTableDemoContainer {
   readonly code = `import { Component, ViewEncapsulation } from '@angular/core';
 import {
   ScTable,
-  ScTableContainer,
   ScTableBody,
   ScTableCell,
+  ScTableContainer,
   ScTableHeader,
   ScTableHeaderCell,
   ScTableRow,

--- a/apps/showcase/src/app/routes/components.routes.ts
+++ b/apps/showcase/src/app/routes/components.routes.ts
@@ -576,6 +576,11 @@ export const componentsRoutes: Route[] = [
           import('../pages/docs/time-picker-clock/time-picker-clock-page'),
       },
       {
+        path: 'marker',
+        title: 'Marker - Semantic Components',
+        loadComponent: () => import('../pages/docs/marker/marker-page'),
+      },
+      {
         path: 'timeline',
         title: 'Timeline - Semantic Components',
         loadComponent: () => import('../pages/docs/timeline/timeline-page'),

--- a/apps/showcase/src/app/routes/demos.routes.ts
+++ b/apps/showcase/src/app/routes/demos.routes.ts
@@ -3715,6 +3715,18 @@ export const demosRoutes: Route[] = [
     ],
   },
   {
+    path: 'demos/marker',
+    children: [
+      {
+        path: 'basic-marker-demo',
+        loadComponent: () =>
+          import('../pages/docs/marker/demos/basic-marker-demo').then(
+            (m) => m.BasicMarkerDemo,
+          ),
+      },
+    ],
+  },
+  {
     path: 'demos/timeline',
     children: [
       {

--- a/libs/ui-lab/package.json
+++ b/libs/ui-lab/package.json
@@ -14,6 +14,7 @@
   },
   "peerDependencies": {
     "@angular/core": ">=21.1.0",
+    "class-variance-authority": ">=0.7.1",
     "@angular/router": ">=21.1.1",
     "@angular/cdk": ">=21.1.1",
     "@angular/common": ">=21.1.1",

--- a/libs/ui-lab/src/lib/components/index.ts
+++ b/libs/ui-lab/src/lib/components/index.ts
@@ -29,6 +29,7 @@ export * from './stat-card';
 export * from './stepper';
 export * from './tags-input';
 export * from './time-picker-clock';
+export * from './marker';
 export * from './timeline';
 export * from './tour-guide';
 export * from './transfer-list';

--- a/libs/ui-lab/src/lib/components/marker/README.md
+++ b/libs/ui-lab/src/lib/components/marker/README.md
@@ -1,0 +1,56 @@
+# Marker
+
+Labels a point in a list or feed — a date divider, an unread boundary, or a
+short inline note.
+
+## Usage
+
+```typescript
+import { ScMarker, ScMarkerContent, ScMarkerIcon } from '@semantic-components/ui-lab';
+```
+
+```html
+<div scMarker>
+  <span scMarkerIcon><svg siInfoIcon></svg></span>
+  <span scMarkerContent>Draft saved a moment ago</span>
+</div>
+```
+
+## Components
+
+All directives accept a `class` input for merging additional CSS classes via
+the `cn` utility.
+
+### ScMarker
+
+| Property | Details                                         |
+| -------- | ----------------------------------------------- |
+| Selector | `div[scMarker], a[scMarker]`                    |
+| Inputs   | `variant`: `default` \| `separator` \| `border` |
+
+`a` is a valid host so a marker can link back to whatever it marks; the
+underline styling only applies in that case.
+
+| Variant     | Rendering                                                    |
+| ----------- | ------------------------------------------------------------ |
+| `default`   | Plain inline row.                                            |
+| `separator` | Centres the content between two horizontal rules.            |
+| `border`    | Adds a bottom border, for separating a section that follows. |
+
+### ScMarkerIcon
+
+| Property        | Details                                      |
+| --------------- | -------------------------------------------- |
+| Selector        | `span[scMarkerIcon]`                         |
+| Default classes | `size-4 shrink-0` and normalises a child svg |
+
+Marked `aria-hidden`, since the icon repeats what the content says.
+
+### ScMarkerContent
+
+| Property | Details                 |
+| -------- | ----------------------- |
+| Selector | `span[scMarkerContent]` |
+
+Wraps long text rather than overflowing, and centres itself under the
+`separator` variant.

--- a/libs/ui-lab/src/lib/components/marker/index.ts
+++ b/libs/ui-lab/src/lib/components/marker/index.ts
@@ -1,0 +1,3 @@
+export * from './marker';
+export * from './marker-icon';
+export * from './marker-content';

--- a/libs/ui-lab/src/lib/components/marker/marker-content.ts
+++ b/libs/ui-lab/src/lib/components/marker/marker-content.ts
@@ -1,0 +1,20 @@
+import { Directive, computed, input } from '@angular/core';
+import { cn } from '@semantic-components/ui';
+
+@Directive({
+  selector: 'span[scMarkerContent]',
+  host: {
+    'data-slot': 'marker-content',
+    '[class]': 'class()',
+  },
+})
+export class ScMarkerContent {
+  readonly classInput = input<string>('', { alias: 'class' });
+
+  protected readonly class = computed(() =>
+    cn(
+      'min-w-0 wrap-break-word group-data-[variant=separator]/marker:flex-none group-data-[variant=separator]/marker:text-center *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground',
+      this.classInput(),
+    ),
+  );
+}

--- a/libs/ui-lab/src/lib/components/marker/marker-icon.ts
+++ b/libs/ui-lab/src/lib/components/marker/marker-icon.ts
@@ -1,0 +1,21 @@
+import { Directive, computed, input } from '@angular/core';
+import { cn } from '@semantic-components/ui';
+
+@Directive({
+  selector: 'span[scMarkerIcon]',
+  host: {
+    'data-slot': 'marker-icon',
+    'aria-hidden': 'true',
+    '[class]': 'class()',
+  },
+})
+export class ScMarkerIcon {
+  readonly classInput = input<string>('', { alias: 'class' });
+
+  protected readonly class = computed(() =>
+    cn(
+      "size-4 shrink-0 [&_svg:not([class*='size-'])]:size-4",
+      this.classInput(),
+    ),
+  );
+}

--- a/libs/ui-lab/src/lib/components/marker/marker.ts
+++ b/libs/ui-lab/src/lib/components/marker/marker.ts
@@ -1,0 +1,41 @@
+import { Directive, computed, input } from '@angular/core';
+import { cn } from '@semantic-components/ui';
+import { type VariantProps, cva } from 'class-variance-authority';
+
+export const markerVariants = cva(
+  "group/marker relative flex min-h-4 w-full items-center gap-2 text-sm text-muted-foreground text-start [a]:underline [a]:underline-offset-3 [a]:hover:text-foreground [&_svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      variant: {
+        default: '',
+        separator:
+          'before:h-px before:min-w-0 before:flex-1 before:bg-border before:me-1 after:h-px after:min-w-0 after:flex-1 after:bg-border after:ms-1',
+        border: 'border-b border-border pb-2',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  },
+);
+
+export type ScMarkerVariants = VariantProps<typeof markerVariants>;
+
+@Directive({
+  // `a` is included so the `[a]:*` variants above can match: a marker is
+  // sometimes a link back to the thing it marks.
+  selector: 'div[scMarker], a[scMarker]',
+  host: {
+    'data-slot': 'marker',
+    '[attr.data-variant]': 'variant()',
+    '[class]': 'class()',
+  },
+})
+export class ScMarker {
+  readonly classInput = input<string>('', { alias: 'class' });
+  readonly variant = input<ScMarkerVariants['variant']>('default');
+
+  protected readonly class = computed(() =>
+    cn(markerVariants({ variant: this.variant() }), this.classInput()),
+  );
+}


### PR DESCRIPTION
First of the four components shadcn ships that we don't have. **Marker** labels a point in a list or feed — a date divider, an unread boundary, a short inline note.

Built in `ui-lab` as requested.

## What's here

Three directives in the library's usual shape:

| Directive | Selector | Notes |
|---|---|---|
| `ScMarker` | `div[scMarker], a[scMarker]` | `default` / `separator` / `border` variants |
| `ScMarkerIcon` | `span[scMarkerIcon]` | `aria-hidden`, normalises a child svg |
| `ScMarkerContent` | `span[scMarkerContent]` | wraps long text, centres under `separator` |

Matches `.cn-marker`, `.cn-marker-icon` and `.cn-marker-content` from `style-nova.css`, RTL-normalised — upstream's `before:mr-1`/`after:ml-1` become `before:me-1`/`after:ms-1`, `text-left` becomes `text-start`.

**`a` is a valid host** for `ScMarker`. Upstream's version renders as any tag and its base carries `[a]:underline` and `[a]:hover:text-foreground`, which only apply when the element *is* an anchor. Admitting `a` is what makes those reachable — the same fix as badge and item in #1504.

Ships with a demo covering all three variants, a docs page, and both route registrations.

## Also: a fix for my own mistake in #1529

Five table demo containers were left **out of sync** by that PR. `sync-demo-code` ran *before* the pre-commit prettier hook reordered imports in the demo sources, so the generated `code` strings kept the old order.

`validate-demo-code` reports it and **it isn't part of CI**, so it went unnoticed. Confirmed by stashing my changes and running the validator against `main`: 5 mismatches. Regenerated here.

The lesson is ordering — generate after formatting, not before. I hit it again in this PR and caught it the second time by running validate → sync → validate.

## Verification

`nx lint` across `ui-lab` and `showcase` — 42 warnings, matching baseline. `tsc --noEmit` clean for both the lib and the app; `validate-demo-code` 0 mismatches; 56/56 tests.

Next: `attachment`, then `bubble`, then `message`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)