### PR TITLE
feat(ui-lab): add Bubble

### DIFF
--- a/apps/showcase/src/app/pages/docs/bubble/bubble-page.ts
+++ b/apps/showcase/src/app/pages/docs/bubble/bubble-page.ts
@@ -1,0 +1,29 @@
+import { Component, ViewEncapsulation } from '@angular/core';
+import { ScHeading } from '@semantic-components/ui';
+import { ComponentBadges } from '../../../components/component-badges/component-badges';
+import { TocHeading } from '../../../components/toc/toc-heading';
+import { BasicBubbleDemoContainer } from './demos/basic-bubble-demo-container';
+
+@Component({
+  selector: 'app-bubble-page',
+  imports: [BasicBubbleDemoContainer, TocHeading, ComponentBadges, ScHeading],
+  template: `
+    <div class="space-y-8">
+      <div class="space-y-2">
+        <h1 scHeading>Bubble</h1>
+        <p class="text-muted-foreground">
+          A single message in a conversation, aligned to either side and
+          optionally carrying reactions.
+        </p>
+        <app-component-badges path="bubble" />
+      </div>
+
+      <section class="space-y-8">
+        <h2 scHeading appToc>Examples</h2>
+        <app-basic-bubble-demo-container />
+      </section>
+    </div>
+  `,
+  encapsulation: ViewEncapsulation.None,
+})
+export default class BubblePage {}

--- a/apps/showcase/src/app/pages/docs/bubble/demos/basic-bubble-demo-container.ts
+++ b/apps/showcase/src/app/pages/docs/bubble/demos/basic-bubble-demo-container.ts
@@ -1,0 +1,52 @@
+import { Component, ViewEncapsulation } from '@angular/core';
+import { DemoContainer } from '../../../../components/demo-container/demo-container';
+import { BasicBubbleDemo } from './basic-bubble-demo';
+
+@Component({
+  selector: 'app-basic-bubble-demo-container',
+  imports: [DemoContainer, BasicBubbleDemo],
+  template: `
+    <app-demo-container
+      title="Basic"
+      demoUrl="/demos/bubble/basic-bubble-demo"
+      [code]="code"
+    >
+      <app-basic-bubble-demo />
+    </app-demo-container>
+  `,
+  host: { class: 'block w-full' },
+  encapsulation: ViewEncapsulation.None,
+})
+export class BasicBubbleDemoContainer {
+  readonly code = `import { Component, ViewEncapsulation } from '@angular/core';
+import {
+  ScBubble,
+  ScBubbleContent,
+  ScBubbleGroup,
+  ScBubbleReactions,
+} from '@semantic-components/ui-lab';
+
+@Component({
+  selector: 'app-basic-bubble-demo',
+  imports: [ScBubbleGroup, ScBubble, ScBubbleContent, ScBubbleReactions],
+  template: \`
+    <div scBubbleGroup class="w-full max-w-md">
+      <div scBubble variant="muted">
+        <div scBubbleContent>Are we still on for tomorrow?</div>
+      </div>
+
+      <div scBubble align="end" class="mb-3">
+        <div scBubbleContent>Yes — 10am works.</div>
+        <div scBubbleReactions side="bottom" align="end">👍</div>
+      </div>
+
+      <div scBubble variant="muted">
+        <div scBubbleContent>Perfect, see you then.</div>
+      </div>
+    </div>
+  \`,
+  host: { class: 'flex w-full justify-center' },
+  encapsulation: ViewEncapsulation.None,
+})
+export class BasicBubbleDemo {}`;
+}

--- a/apps/showcase/src/app/pages/docs/bubble/demos/basic-bubble-demo.ts
+++ b/apps/showcase/src/app/pages/docs/bubble/demos/basic-bubble-demo.ts
@@ -1,0 +1,31 @@
+import { Component, ViewEncapsulation } from '@angular/core';
+import {
+  ScBubble,
+  ScBubbleContent,
+  ScBubbleGroup,
+  ScBubbleReactions,
+} from '@semantic-components/ui-lab';
+
+@Component({
+  selector: 'app-basic-bubble-demo',
+  imports: [ScBubbleGroup, ScBubble, ScBubbleContent, ScBubbleReactions],
+  template: `
+    <div scBubbleGroup class="w-full max-w-md">
+      <div scBubble variant="muted">
+        <div scBubbleContent>Are we still on for tomorrow?</div>
+      </div>
+
+      <div scBubble align="end" class="mb-3">
+        <div scBubbleContent>Yes — 10am works.</div>
+        <div scBubbleReactions side="bottom" align="end">👍</div>
+      </div>
+
+      <div scBubble variant="muted">
+        <div scBubbleContent>Perfect, see you then.</div>
+      </div>
+    </div>
+  `,
+  host: { class: 'flex w-full justify-center' },
+  encapsulation: ViewEncapsulation.None,
+})
+export class BasicBubbleDemo {}

--- a/apps/showcase/src/app/routes/components.routes.ts
+++ b/apps/showcase/src/app/routes/components.routes.ts
@@ -581,6 +581,11 @@ export const componentsRoutes: Route[] = [
         loadComponent: () => import('../pages/docs/attachment/attachment-page'),
       },
       {
+        path: 'bubble',
+        title: 'Bubble - Semantic Components',
+        loadComponent: () => import('../pages/docs/bubble/bubble-page'),
+      },
+      {
         path: 'marker',
         title: 'Marker - Semantic Components',
         loadComponent: () => import('../pages/docs/marker/marker-page'),

--- a/apps/showcase/src/app/routes/demos.routes.ts
+++ b/apps/showcase/src/app/routes/demos.routes.ts
@@ -3727,6 +3727,18 @@ export const demosRoutes: Route[] = [
     ],
   },
   {
+    path: 'demos/bubble',
+    children: [
+      {
+        path: 'basic-bubble-demo',
+        loadComponent: () =>
+          import('../pages/docs/bubble/demos/basic-bubble-demo').then(
+            (m) => m.BasicBubbleDemo,
+          ),
+      },
+    ],
+  },
+  {
     path: 'demos/marker',
     children: [
       {

--- a/libs/ui-lab/src/lib/components/bubble/README.md
+++ b/libs/ui-lab/src/lib/components/bubble/README.md
@@ -1,0 +1,66 @@
+# Bubble
+
+A single message in a conversation, aligned to either side and optionally
+carrying reactions.
+
+## Usage
+
+```typescript
+import { ScBubble, ScBubbleContent, ScBubbleGroup, ScBubbleReactions } from '@semantic-components/ui-lab';
+```
+
+```html
+<div scBubbleGroup>
+  <div scBubble variant="muted">
+    <div scBubbleContent>Are we still on for tomorrow?</div>
+  </div>
+  <div scBubble align="end">
+    <div scBubbleContent>Yes — 10am works.</div>
+  </div>
+</div>
+```
+
+## Components
+
+All directives accept a `class` input for merging additional CSS classes via
+the `cn` utility.
+
+### ScBubble
+
+| Property | Details                             |
+| -------- | ----------------------------------- |
+| Selector | `div[scBubble]`                     |
+| Inputs   | `align`: `start` (default) \| `end` |
+|          | `variant`: see below                |
+
+`align="end"` pushes the bubble to the inline end, for the current user's own
+messages. A bubble also follows `data-align` on a surrounding message.
+
+Variants: `default`, `secondary`, `muted`, `tinted`, `outline`, `ghost`,
+`destructive`. They style the content rather than the bubble itself, so the
+alignment wrapper stays transparent. `ghost` drops the padding and background
+entirely and allows full width.
+
+### ScBubbleContent
+
+| Property | Details                                                                 |
+| -------- | ----------------------------------------------------------------------- |
+| Selector | `div[scBubbleContent]`, `button[scBubbleContent]`, `a[scBubbleContent]` |
+
+`button` and `a` are valid hosts, since a bubble is sometimes tappable. The
+hover, focus-ring and transition rules only apply on those elements.
+
+### ScBubbleReactions
+
+| Property | Details                             |
+| -------- | ----------------------------------- |
+| Selector | `div[scBubbleReactions]`            |
+| Inputs   | `side`: `top` \| `bottom` (default) |
+|          | `align`: `start` (default) \| `end` |
+
+Overlaps the bubble's edge. Leave room for it — the demo adds a bottom margin
+to the bubble it hangs off.
+
+### ScBubbleGroup
+
+Stacks bubbles in a column.

--- a/libs/ui-lab/src/lib/components/bubble/bubble-content.ts
+++ b/libs/ui-lab/src/lib/components/bubble/bubble-content.ts
@@ -1,0 +1,24 @@
+import { Directive, computed, input } from '@angular/core';
+import { cn } from '@semantic-components/ui';
+
+/**
+ * `button` and `a` are valid hosts: a bubble is sometimes tappable, and the
+ * `[button,a]:*` focus and transition rules only apply on those elements.
+ */
+@Directive({
+  selector: 'div[scBubbleContent], button[scBubbleContent], a[scBubbleContent]',
+  host: {
+    'data-slot': 'bubble-content',
+    '[class]': 'class()',
+  },
+})
+export class ScBubbleContent {
+  readonly classInput = input<string>('', { alias: 'class' });
+
+  protected readonly class = computed(() =>
+    cn(
+      'w-fit max-w-full min-w-0 overflow-hidden rounded-xl border border-transparent px-3 py-2 text-sm leading-relaxed wrap-break-word group-data-[align=end]/bubble:self-end [button]:text-start [button,a]:outline-none [button,a]:transition-colors [button,a]:focus-visible:border-ring [button,a]:focus-visible:ring-3 [button,a]:focus-visible:ring-ring/50',
+      this.classInput(),
+    ),
+  );
+}

--- a/libs/ui-lab/src/lib/components/bubble/bubble-group.ts
+++ b/libs/ui-lab/src/lib/components/bubble/bubble-group.ts
@@ -1,0 +1,17 @@
+import { Directive, computed, input } from '@angular/core';
+import { cn } from '@semantic-components/ui';
+
+@Directive({
+  selector: 'div[scBubbleGroup]',
+  host: {
+    'data-slot': 'bubble-group',
+    '[class]': 'class()',
+  },
+})
+export class ScBubbleGroup {
+  readonly classInput = input<string>('', { alias: 'class' });
+
+  protected readonly class = computed(() =>
+    cn('flex min-w-0 flex-col gap-2', this.classInput()),
+  );
+}

--- a/libs/ui-lab/src/lib/components/bubble/bubble-reactions.ts
+++ b/libs/ui-lab/src/lib/components/bubble/bubble-reactions.ts
@@ -1,0 +1,47 @@
+import { Directive, computed, input } from '@angular/core';
+import { cn } from '@semantic-components/ui';
+import { type VariantProps, cva } from 'class-variance-authority';
+
+export const bubbleReactionsVariants = cva(
+  'absolute z-10 flex w-fit shrink-0 items-center justify-center gap-1 rounded-full bg-muted px-1.5 py-0.5 text-sm ring-3 ring-card has-[button]:p-0',
+  {
+    variants: {
+      side: {
+        top: 'top-0 -translate-y-3/4',
+        bottom: 'bottom-0 translate-y-3/4',
+      },
+      align: {
+        start: 'start-3',
+        end: 'end-3',
+      },
+    },
+    defaultVariants: {
+      side: 'bottom',
+      align: 'start',
+    },
+  },
+);
+
+export type ScBubbleReactionsVariants = VariantProps<
+  typeof bubbleReactionsVariants
+>;
+
+@Directive({
+  selector: 'div[scBubbleReactions]',
+  host: {
+    'data-slot': 'bubble-reactions',
+    '[class]': 'class()',
+  },
+})
+export class ScBubbleReactions {
+  readonly classInput = input<string>('', { alias: 'class' });
+  readonly side = input<ScBubbleReactionsVariants['side']>('bottom');
+  readonly align = input<ScBubbleReactionsVariants['align']>('start');
+
+  protected readonly class = computed(() =>
+    cn(
+      bubbleReactionsVariants({ side: this.side(), align: this.align() }),
+      this.classInput(),
+    ),
+  );
+}

--- a/libs/ui-lab/src/lib/components/bubble/bubble.ts
+++ b/libs/ui-lab/src/lib/components/bubble/bubble.ts
@@ -1,0 +1,51 @@
+import { Directive, computed, input } from '@angular/core';
+import { cn } from '@semantic-components/ui';
+import { type VariantProps, cva } from 'class-variance-authority';
+
+export const bubbleVariants = cva(
+  'group/bubble relative flex w-fit max-w-[80%] min-w-0 flex-col gap-1 data-[align=end]:self-end data-[variant=ghost]:max-w-full group-data-[align=end]/message:self-end',
+  {
+    variants: {
+      variant: {
+        default:
+          '*:data-[slot=bubble-content]:bg-primary *:data-[slot=bubble-content]:text-primary-foreground [&>[data-slot=bubble-content]:is(button,a):hover]:bg-primary/80',
+        secondary:
+          '*:data-[slot=bubble-content]:bg-secondary *:data-[slot=bubble-content]:text-secondary-foreground [&>[data-slot=bubble-content]:is(button,a):hover]:bg-[color-mix(in_oklch,var(--secondary),var(--foreground)_5%)]',
+        muted:
+          '*:data-[slot=bubble-content]:bg-muted [&>[data-slot=bubble-content]:is(button,a):hover]:bg-[color-mix(in_oklch,var(--muted),var(--foreground)_5%)]',
+        tinted:
+          '*:data-[slot=bubble-content]:bg-[oklch(from_var(--primary)_0.93_calc(c*0.4)_h)] *:data-[slot=bubble-content]:text-foreground dark:*:data-[slot=bubble-content]:bg-[oklch(from_var(--primary)_0.3_calc(c*0.4)_h)] [&>[data-slot=bubble-content]:is(button,a):hover]:bg-[oklch(from_var(--primary)_0.88_calc(c*0.5)_h)] dark:[&>[data-slot=bubble-content]:is(button,a):hover]:bg-[oklch(from_var(--primary)_0.35_calc(c*0.5)_h)]',
+        outline:
+          '*:data-[slot=bubble-content]:border-border *:data-[slot=bubble-content]:bg-background [&>[data-slot=bubble-content]:is(button,a):hover]:bg-muted [&>[data-slot=bubble-content]:is(button,a):hover]:text-foreground dark:[&>[data-slot=bubble-content]:is(button,a):hover]:bg-input/30',
+        ghost:
+          'border-none *:data-[slot=bubble-content]:rounded-none *:data-[slot=bubble-content]:bg-transparent *:data-[slot=bubble-content]:p-0 [&>[data-slot=bubble-content]:is(button,a):hover]:bg-muted [&>[data-slot=bubble-content]:is(button,a):hover]:text-foreground dark:[&>[data-slot=bubble-content]:is(button,a):hover]:bg-muted/50',
+        destructive:
+          '*:data-[slot=bubble-content]:bg-destructive/10 *:data-[slot=bubble-content]:text-destructive dark:*:data-[slot=bubble-content]:bg-destructive/20 [&>[data-slot=bubble-content]:is(button,a):hover]:bg-destructive/20 dark:[&>[data-slot=bubble-content]:is(button,a):hover]:bg-destructive/30',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  },
+);
+
+export type ScBubbleVariants = VariantProps<typeof bubbleVariants>;
+
+@Directive({
+  selector: 'div[scBubble]',
+  host: {
+    'data-slot': 'bubble',
+    '[attr.data-align]': 'align()',
+    '[attr.data-variant]': 'variant()',
+    '[class]': 'class()',
+  },
+})
+export class ScBubble {
+  readonly classInput = input<string>('', { alias: 'class' });
+  readonly align = input<'start' | 'end'>('start');
+  readonly variant = input<ScBubbleVariants['variant']>('default');
+
+  protected readonly class = computed(() =>
+    cn(bubbleVariants({ variant: this.variant() }), this.classInput()),
+  );
+}

--- a/libs/ui-lab/src/lib/components/bubble/index.ts
+++ b/libs/ui-lab/src/lib/components/bubble/index.ts
@@ -1,0 +1,4 @@
+export * from './bubble';
+export * from './bubble-content';
+export * from './bubble-reactions';
+export * from './bubble-group';

--- a/libs/ui-lab/src/lib/components/index.ts
+++ b/libs/ui-lab/src/lib/components/index.ts
@@ -1,6 +1,7 @@
 export * from './attachment';
 export * from './audio-player';
 export * from './barcode-scanner';
+export * from './bubble';
 export * from './color-picker';
 export * from './countdown';
 export * from './data-table';


### PR DESCRIPTION
Third of the four. **Bubble** is a single message in a conversation, aligned to either side and optionally carrying reactions.

## What's here

| Directive | Notes |
|---|---|
| `ScBubble` | `align` (`start`/`end`) and seven variants |
| `ScBubbleContent` | `div`, `button` or `a` host |
| `ScBubbleReactions` | `side` (`top`/`bottom`), `align` (`start`/`end`) |
| `ScBubbleGroup` | stacks bubbles in a column |

Variants: `default`, `secondary`, `muted`, `tinted`, `outline`, `ghost`, `destructive`.

## Two structural points worth knowing

**The variants style the content, not the bubble.** They work through `*:data-[slot=bubble-content]` selectors, so the alignment wrapper stays transparent. That's upstream's arrangement, and it's what lets `ghost` drop the padding and background entirely while the wrapper keeps handling layout and max-width.

**`button` and `a` are valid hosts for the content.** Upstream's `[button,a]:*` hover, focus-ring and transition rules only apply on those elements — admitting them is what makes a tappable bubble actually work. Same reasoning as marker's anchor host in #1531.

RTL-normalised: reactions align to `start-3`/`end-3` rather than `left-3`/`right-3`, and the content's `[button]:text-left` becomes `text-start`.

## Verification

`nx run-many -t lint` **exits 0**; `tsc --noEmit` clean for lib and app; `validate-demo-code` 0 mismatches, re-checked after the pre-commit hook; 56/56 tests. `bubble` sorts into the barrel alphabetically, per the ordering fixed in #1532.

Last one next: `message`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)