### PR TITLE
feat(ui-lab): add Message

### DIFF
--- a/apps/showcase/src/app/pages/docs/message/demos/basic-message-demo-container.ts
+++ b/apps/showcase/src/app/pages/docs/message/demos/basic-message-demo-container.ts
@@ -1,0 +1,79 @@
+import { Component, ViewEncapsulation } from '@angular/core';
+import { DemoContainer } from '../../../../components/demo-container/demo-container';
+import { BasicMessageDemo } from './basic-message-demo';
+
+@Component({
+  selector: 'app-basic-message-demo-container',
+  imports: [DemoContainer, BasicMessageDemo],
+  template: `
+    <app-demo-container
+      title="Basic"
+      demoUrl="/demos/message/basic-message-demo"
+      [code]="code"
+    >
+      <app-basic-message-demo />
+    </app-demo-container>
+  `,
+  host: { class: 'block w-full' },
+  encapsulation: ViewEncapsulation.None,
+})
+export class BasicMessageDemoContainer {
+  readonly code = `import { Component, ViewEncapsulation } from '@angular/core';
+import { ScAvatar, ScAvatarFallback } from '@semantic-components/ui';
+import {
+  ScBubble,
+  ScBubbleContent,
+  ScMessage,
+  ScMessageAvatar,
+  ScMessageContent,
+  ScMessageFooter,
+  ScMessageGroup,
+  ScMessageHeader,
+} from '@semantic-components/ui-lab';
+
+@Component({
+  selector: 'app-basic-message-demo',
+  imports: [
+    ScMessageGroup,
+    ScMessage,
+    ScMessageAvatar,
+    ScMessageContent,
+    ScMessageHeader,
+    ScMessageFooter,
+    ScBubble,
+    ScBubbleContent,
+    ScAvatar,
+    ScAvatarFallback,
+  ],
+  template: \`
+    <div scMessageGroup class="w-full max-w-lg">
+      <div scMessage>
+        <div scMessageAvatar>
+          <span scAvatar><span scAvatarFallback>AR</span></span>
+        </div>
+        <div scMessageContent>
+          <div scMessageHeader>Ada</div>
+          <div scBubble variant="muted">
+            <div scBubbleContent>The build is green again.</div>
+          </div>
+        </div>
+      </div>
+
+      <div scMessage align="end">
+        <div scMessageAvatar>
+          <span scAvatar><span scAvatarFallback>ME</span></span>
+        </div>
+        <div scMessageContent>
+          <div scBubble align="end">
+            <div scBubbleContent>Nice — shipping it now.</div>
+          </div>
+          <div scMessageFooter>Sent 10:42</div>
+        </div>
+      </div>
+    </div>
+  \`,
+  host: { class: 'flex w-full justify-center' },
+  encapsulation: ViewEncapsulation.None,
+})
+export class BasicMessageDemo {}`;
+}

--- a/apps/showcase/src/app/pages/docs/message/demos/basic-message-demo.ts
+++ b/apps/showcase/src/app/pages/docs/message/demos/basic-message-demo.ts
@@ -1,0 +1,58 @@
+import { Component, ViewEncapsulation } from '@angular/core';
+import { ScAvatar, ScAvatarFallback } from '@semantic-components/ui';
+import {
+  ScBubble,
+  ScBubbleContent,
+  ScMessage,
+  ScMessageAvatar,
+  ScMessageContent,
+  ScMessageFooter,
+  ScMessageGroup,
+  ScMessageHeader,
+} from '@semantic-components/ui-lab';
+
+@Component({
+  selector: 'app-basic-message-demo',
+  imports: [
+    ScMessageGroup,
+    ScMessage,
+    ScMessageAvatar,
+    ScMessageContent,
+    ScMessageHeader,
+    ScMessageFooter,
+    ScBubble,
+    ScBubbleContent,
+    ScAvatar,
+    ScAvatarFallback,
+  ],
+  template: `
+    <div scMessageGroup class="w-full max-w-lg">
+      <div scMessage>
+        <div scMessageAvatar>
+          <span scAvatar><span scAvatarFallback>AR</span></span>
+        </div>
+        <div scMessageContent>
+          <div scMessageHeader>Ada</div>
+          <div scBubble variant="muted">
+            <div scBubbleContent>The build is green again.</div>
+          </div>
+        </div>
+      </div>
+
+      <div scMessage align="end">
+        <div scMessageAvatar>
+          <span scAvatar><span scAvatarFallback>ME</span></span>
+        </div>
+        <div scMessageContent>
+          <div scBubble align="end">
+            <div scBubbleContent>Nice — shipping it now.</div>
+          </div>
+          <div scMessageFooter>Sent 10:42</div>
+        </div>
+      </div>
+    </div>
+  `,
+  host: { class: 'flex w-full justify-center' },
+  encapsulation: ViewEncapsulation.None,
+})
+export class BasicMessageDemo {}

--- a/apps/showcase/src/app/pages/docs/message/message-page.ts
+++ b/apps/showcase/src/app/pages/docs/message/message-page.ts
@@ -1,0 +1,29 @@
+import { Component, ViewEncapsulation } from '@angular/core';
+import { ScHeading } from '@semantic-components/ui';
+import { ComponentBadges } from '../../../components/component-badges/component-badges';
+import { TocHeading } from '../../../components/toc/toc-heading';
+import { BasicMessageDemoContainer } from './demos/basic-message-demo-container';
+
+@Component({
+  selector: 'app-message-page',
+  imports: [BasicMessageDemoContainer, TocHeading, ComponentBadges, ScHeading],
+  template: `
+    <div class="space-y-8">
+      <div class="space-y-2">
+        <h1 scHeading>Message</h1>
+        <p class="text-muted-foreground">
+          A row in a conversation: an avatar beside a column of bubbles, with an
+          optional header and footer.
+        </p>
+        <app-component-badges path="message" />
+      </div>
+
+      <section class="space-y-8">
+        <h2 scHeading appToc>Examples</h2>
+        <app-basic-message-demo-container />
+      </section>
+    </div>
+  `,
+  encapsulation: ViewEncapsulation.None,
+})
+export default class MessagePage {}

--- a/apps/showcase/src/app/routes/components.routes.ts
+++ b/apps/showcase/src/app/routes/components.routes.ts
@@ -586,6 +586,11 @@ export const componentsRoutes: Route[] = [
         loadComponent: () => import('../pages/docs/bubble/bubble-page'),
       },
       {
+        path: 'message',
+        title: 'Message - Semantic Components',
+        loadComponent: () => import('../pages/docs/message/message-page'),
+      },
+      {
         path: 'marker',
         title: 'Marker - Semantic Components',
         loadComponent: () => import('../pages/docs/marker/marker-page'),

--- a/apps/showcase/src/app/routes/demos.routes.ts
+++ b/apps/showcase/src/app/routes/demos.routes.ts
@@ -3739,6 +3739,18 @@ export const demosRoutes: Route[] = [
     ],
   },
   {
+    path: 'demos/message',
+    children: [
+      {
+        path: 'basic-message-demo',
+        loadComponent: () =>
+          import('../pages/docs/message/demos/basic-message-demo').then(
+            (m) => m.BasicMessageDemo,
+          ),
+      },
+    ],
+  },
+  {
     path: 'demos/marker',
     children: [
       {

--- a/libs/ui-lab/src/lib/components/index.ts
+++ b/libs/ui-lab/src/lib/components/index.ts
@@ -20,6 +20,7 @@ export * from './marker';
 export * from './marquee';
 export * from './masonry-grid';
 export * from './mention-input';
+export * from './message';
 export * from './native-dialog';
 export * from './navbar';
 export * from './notification-center';

--- a/libs/ui-lab/src/lib/components/message/README.md
+++ b/libs/ui-lab/src/lib/components/message/README.md
@@ -1,0 +1,65 @@
+# Message
+
+A row in a conversation: an avatar beside a column of bubbles, with an
+optional header and footer.
+
+Pairs with [Bubble](../bubble/README.md) — a bubble reads the message's
+alignment and pushes itself to the matching side.
+
+## Usage
+
+```typescript
+import { ScMessage, ScMessageAvatar, ScMessageContent, ScMessageGroup, ScMessageHeader } from '@semantic-components/ui-lab';
+```
+
+```html
+<div scMessageGroup>
+  <div scMessage>
+    <div scMessageAvatar>
+      <span scAvatar><span scAvatarFallback>AR</span></span>
+    </div>
+    <div scMessageContent>
+      <div scMessageHeader>Ada</div>
+      <div scBubble variant="muted">
+        <div scBubbleContent>The build is green again.</div>
+      </div>
+    </div>
+  </div>
+</div>
+```
+
+## Components
+
+All directives accept a `class` input for merging additional CSS classes via
+the `cn` utility.
+
+### ScMessage
+
+| Property | Details                             |
+| -------- | ----------------------------------- |
+| Selector | `div[scMessage]`                    |
+| Inputs   | `align`: `start` (default) \| `end` |
+
+`align="end"` reverses the row so the avatar sits on the inline end. It is
+published as `data-align`, which `ScBubble` and `ScMessageContent` both read —
+the bubbles in an end-aligned message align themselves without being told
+individually.
+
+### ScMessageAvatar
+
+Sits at the bottom of the row. Lifts itself when the message has a footer, so
+it stays level with the last bubble rather than the timestamp.
+
+### ScMessageContent
+
+The column of bubbles.
+
+### ScMessageHeader and ScMessageFooter
+
+Small muted lines above and below the bubbles — a sender name, a timestamp, a
+delivery state. Both drop their horizontal padding when the message contains a
+`ghost` bubble, so the text lines up with the unpadded content.
+
+### ScMessageGroup
+
+Stacks messages in a column.

--- a/libs/ui-lab/src/lib/components/message/index.ts
+++ b/libs/ui-lab/src/lib/components/message/index.ts
@@ -1,0 +1,6 @@
+export * from './message';
+export * from './message-avatar';
+export * from './message-content';
+export * from './message-header';
+export * from './message-footer';
+export * from './message-group';

--- a/libs/ui-lab/src/lib/components/message/message-avatar.ts
+++ b/libs/ui-lab/src/lib/components/message/message-avatar.ts
@@ -1,0 +1,20 @@
+import { Directive, computed, input } from '@angular/core';
+import { cn } from '@semantic-components/ui';
+
+@Directive({
+  selector: 'div[scMessageAvatar]',
+  host: {
+    'data-slot': 'message-avatar',
+    '[class]': 'class()',
+  },
+})
+export class ScMessageAvatar {
+  readonly classInput = input<string>('', { alias: 'class' });
+
+  protected readonly class = computed(() =>
+    cn(
+      'flex w-fit min-w-8 shrink-0 items-center justify-center self-end overflow-hidden rounded-full bg-muted group-has-data-[slot=message-footer]/message:-translate-y-8',
+      this.classInput(),
+    ),
+  );
+}

--- a/libs/ui-lab/src/lib/components/message/message-content.ts
+++ b/libs/ui-lab/src/lib/components/message/message-content.ts
@@ -1,0 +1,20 @@
+import { Directive, computed, input } from '@angular/core';
+import { cn } from '@semantic-components/ui';
+
+@Directive({
+  selector: 'div[scMessageContent]',
+  host: {
+    'data-slot': 'message-content',
+    '[class]': 'class()',
+  },
+})
+export class ScMessageContent {
+  readonly classInput = input<string>('', { alias: 'class' });
+
+  protected readonly class = computed(() =>
+    cn(
+      'flex w-full min-w-0 flex-col gap-2.5 wrap-break-word group-data-[align=end]/message:*:data-slot:self-end',
+      this.classInput(),
+    ),
+  );
+}

--- a/libs/ui-lab/src/lib/components/message/message-footer.ts
+++ b/libs/ui-lab/src/lib/components/message/message-footer.ts
@@ -1,0 +1,20 @@
+import { Directive, computed, input } from '@angular/core';
+import { cn } from '@semantic-components/ui';
+
+@Directive({
+  selector: 'div[scMessageFooter]',
+  host: {
+    'data-slot': 'message-footer',
+    '[class]': 'class()',
+  },
+})
+export class ScMessageFooter {
+  readonly classInput = input<string>('', { alias: 'class' });
+
+  protected readonly class = computed(() =>
+    cn(
+      'flex max-w-full min-w-0 items-center px-3 text-xs font-medium text-muted-foreground group-has-data-[variant=ghost]/message:px-0',
+      this.classInput(),
+    ),
+  );
+}

--- a/libs/ui-lab/src/lib/components/message/message-group.ts
+++ b/libs/ui-lab/src/lib/components/message/message-group.ts
@@ -1,0 +1,17 @@
+import { Directive, computed, input } from '@angular/core';
+import { cn } from '@semantic-components/ui';
+
+@Directive({
+  selector: 'div[scMessageGroup]',
+  host: {
+    'data-slot': 'message-group',
+    '[class]': 'class()',
+  },
+})
+export class ScMessageGroup {
+  readonly classInput = input<string>('', { alias: 'class' });
+
+  protected readonly class = computed(() =>
+    cn('flex min-w-0 flex-col gap-2', this.classInput()),
+  );
+}

--- a/libs/ui-lab/src/lib/components/message/message-header.ts
+++ b/libs/ui-lab/src/lib/components/message/message-header.ts
@@ -1,0 +1,20 @@
+import { Directive, computed, input } from '@angular/core';
+import { cn } from '@semantic-components/ui';
+
+@Directive({
+  selector: 'div[scMessageHeader]',
+  host: {
+    'data-slot': 'message-header',
+    '[class]': 'class()',
+  },
+})
+export class ScMessageHeader {
+  readonly classInput = input<string>('', { alias: 'class' });
+
+  protected readonly class = computed(() =>
+    cn(
+      'flex max-w-full min-w-0 items-center px-3 text-xs font-medium text-muted-foreground group-has-data-[variant=ghost]/message:px-0',
+      this.classInput(),
+    ),
+  );
+}

--- a/libs/ui-lab/src/lib/components/message/message.ts
+++ b/libs/ui-lab/src/lib/components/message/message.ts
@@ -1,0 +1,27 @@
+import { Directive, computed, input } from '@angular/core';
+import { cn } from '@semantic-components/ui';
+
+/**
+ * A row in a conversation: an avatar beside a column of bubbles. `align="end"`
+ * reverses the row and is read by ScBubble, which pushes itself to the inline
+ * end in response.
+ */
+@Directive({
+  selector: 'div[scMessage]',
+  host: {
+    'data-slot': 'message',
+    '[attr.data-align]': 'align()',
+    '[class]': 'class()',
+  },
+})
+export class ScMessage {
+  readonly classInput = input<string>('', { alias: 'class' });
+  readonly align = input<'start' | 'end'>('start');
+
+  protected readonly class = computed(() =>
+    cn(
+      'group/message relative flex w-full min-w-0 gap-2 text-sm data-[align=end]:flex-row-reverse',
+      this.classInput(),
+    ),
+  );
+}


### PR DESCRIPTION
Last of the four. **Message** is a row in a conversation: an avatar beside a column of bubbles, with an optional header and footer.

## What's here

Six directives: `ScMessage` (with `align`), plus `Avatar`, `Content`, `Header`, `Footer` and `Group`.

## It composes with Bubble rather than duplicating it

The alignment lives on the message as `data-align`, and **both** `ScBubble` and `ScMessageContent` read it through `group/message`. So the bubbles in an end-aligned message align themselves without being told individually.

Bubble already carried `group-data-[align=end]/message:self-end` when it landed in #1533 — this is the component that finally sets the attribute it was looking for. The demo shows the pair working together.

Two smaller details worth keeping:

- **The avatar lifts itself when the message has a footer**, so it stays level with the last bubble rather than sliding down beside the timestamp.
- **Header and footer drop their horizontal padding around a `ghost` bubble**, which has none of its own, so the text stays aligned with the content.

No RTL work needed — the row reverses through `flex-row-reverse` and the padding is symmetric.

## Verification

`nx run-many -t lint` **exits 0**; `tsc --noEmit` clean for lib and app; `validate-demo-code` 0 mismatches, re-checked after the pre-commit hook; 56/56 tests.

## All four are done

`marker` (#1531), `attachment` (#1532), `bubble` (#1533) and `message` — every component shadcn ships that we were missing now exists in `ui-lab`, each with a demo, docs page, routes and README.

Three upstream utilities remain undefined in this workspace and were deliberately omitted rather than shipped dead: `shimmer`, `scroll-fade-x`, `scrollbar-none`. Defining them would let attachment's uploading state and the group's scroll fade match upstream exactly — worth its own change if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)