### PR TITLE
fix(ui-lab): use the shimmer and scroll-fade utilities in Attachment

### DIFF
--- a/libs/ui-lab/src/lib/components/attachment/README.md
+++ b/libs/ui-lab/src/lib/components/attachment/README.md
@@ -68,12 +68,6 @@ while the actions stay clickable above it.
 
 ### ScAttachmentGroup
 
-A horizontally scrolling, snapping row of attachments.
-
-## Differences from upstream
-
-Three utilities upstream uses are not defined in this workspace, so they are
-omitted rather than shipped as dead classes:
-
-- `shimmer` on the title during `uploading` and `processing`
-- `scroll-fade-x` and `scrollbar-none` on the group
+A horizontally scrolling, snapping row of attachments, with its scrollbar
+hidden and its edges faded via the `no-scrollbar` and `scroll-fade-x`
+utilities from `shadcn/tailwind.css`.

--- a/libs/ui-lab/src/lib/components/attachment/attachment-group.ts
+++ b/libs/ui-lab/src/lib/components/attachment/attachment-group.ts
@@ -13,7 +13,7 @@ export class ScAttachmentGroup {
 
   protected readonly class = computed(() =>
     cn(
-      'flex min-w-0 snap-x snap-mandatory gap-3 scroll-px-1 overflow-x-auto overscroll-x-contain py-1 *:data-[slot=attachment]:flex-none *:data-[slot=attachment]:snap-start',
+      'flex min-w-0 scroll-fade-x snap-x snap-mandatory no-scrollbar gap-3 scroll-px-1 overflow-x-auto overscroll-x-contain py-1 *:data-[slot=attachment]:flex-none *:data-[slot=attachment]:snap-start',
       this.classInput(),
     ),
   );

--- a/libs/ui-lab/src/lib/components/attachment/attachment-title.ts
+++ b/libs/ui-lab/src/lib/components/attachment/attachment-title.ts
@@ -12,6 +12,9 @@ export class ScAttachmentTitle {
   readonly classInput = input<string>('', { alias: 'class' });
 
   protected readonly class = computed(() =>
-    cn('block max-w-full min-w-0 truncate font-medium', this.classInput()),
+    cn(
+      'block max-w-full min-w-0 truncate font-medium group-data-[state=processing]/attachment:shimmer group-data-[state=uploading]/attachment:shimmer',
+      this.classInput(),
+    ),
   );
 }


### PR DESCRIPTION
**The utilities were never missing.** `libs/ui/src/lib/styles/shadcn.css` imports `shadcn/tailwind.css` on line 3, and that file defines `shimmer`, `scroll-fade-x` and `no-scrollbar`. Compiling the real stylesheet generates all three.

I checked for them in #1532 by grepping **only our own CSS files**, concluded they were unavailable, and left them out of Attachment to avoid shipping dead classes. The premise was wrong.

## What this restores

- **`attachment-title`** shimmers while the attachment is `uploading` or `processing` — verified the variant compiles to `:is(:where(.group\/attachment)[data-state="uploading"] *)`
- **`attachment-group`** hides its scrollbar and fades its edges

## Two more corrections from that PR

- **`no-scrollbar` was never dead.** It's used by `command-list` and `sidebar-body` — not `combobox-list` as I claimed — and it resolves fine. I called it a pre-existing bug; it isn't one.
- **`scrollbar-none`** genuinely is undefined anywhere, including upstream, even though upstream's own attachment references it. The real utility is `no-scrollbar`, which is what this uses.

So the only actual gap was my own verification, not the workspace.

## Verification

Compiled the real `shadcn.css` through the repo's Tailwind and confirmed `.shimmer`, `.scroll-fade-x` and `.no-scrollbar` are all emitted, plus the `group-data-[state=uploading]/attachment:shimmer` variant specifically. `nx run-many -t lint` exits 0; `tsc --noEmit` clean; 56/56 tests.

Worth an eyeball on the attachment demo — the uploading row should now shimmer, and the row should fade at its edges when it overflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)