### PR TITLE
ci: run the unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Lint
         run: npx nx run-many -t lint
 
+      - name: Unit tests
+        run: npx nx run-many -t test
+
       - name: Build
         run: npx nx run-many -t build
 

--- a/apps/blocks/project.json
+++ b/apps/blocks/project.json
@@ -69,10 +69,6 @@
     "lint": {
       "executor": "@nx/eslint:lint"
     },
-    "test": {
-      "executor": "@angular/build:unit-test",
-      "options": {}
-    },
     "serve-static": {
       "continuous": true,
       "executor": "@nx/web:file-server",


### PR DESCRIPTION
CI ran lint, build and the Playwright e2e suite, but **never the vitest unit tests**. All 56 — including the `aria-invalid` and `disabled` behaviour added in #1515, #1516 and #1520 — gated nothing.

## One fix was needed first

`apps/blocks` declared a test target but has **no spec files**, so `nx run-many -t test` exited 1 with `No tests found` and would have failed every build.

That's the pre-existing failure I noticed at the very start of this run and then worked around for two days by only ever running `nx test showcase` directly — which is precisely why I never noticed the unit tests weren't in CI. Removed the empty target; it can come back when blocks has tests.

## What I did not add, and why

**`validate-demo-code`.** The nightly `sync-demo-code` workflow already runs it and opens a PR when the generated code drifts — so the drift I caused in #1529 would have healed itself within a day rather than going unnoticed indefinitely, as I implied in #1531.

Turning that self-healing job into a red build on every PR is a different trade-off, and worth deciding on its own rather than slipping in here.

## Verification

Ran the full CI sequence locally, checking exit codes rather than reading output: `lint` 0, `test` 0 (56 passed), `build` 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)