### PR TITLE
fix(context-menu): open through the menu trigger and a CDK overlay

### DIFF
--- a/apps/showcase/src/app/context-menu.spec.ts
+++ b/apps/showcase/src/app/context-menu.spec.ts
@@ -1,0 +1,105 @@
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import {
+  ScContextMenu,
+  ScContextMenuTrigger,
+  ScMenu,
+  ScMenuContent,
+  ScMenuItem,
+  ScMenuPortal,
+} from '@semantic-components/ui';
+
+@Component({
+  imports: [
+    ScContextMenu,
+    ScContextMenuTrigger,
+    ScMenu,
+    ScMenuContent,
+    ScMenuItem,
+    ScMenuPortal,
+  ],
+  template: `
+    <div scContextMenu>
+      <div scContextMenuTrigger>Right click here</div>
+      <ng-template scMenuPortal>
+        <div scMenu>
+          <ng-template scMenuContent>
+            <div scMenuItem value="Edit">Edit</div>
+          </ng-template>
+        </div>
+      </ng-template>
+    </div>
+  `,
+})
+class Host {}
+
+/** No portal at all — the shape that threw NG0951 with a required query. */
+@Component({
+  imports: [ScContextMenu, ScContextMenuTrigger],
+  template: `
+    <div scContextMenu>
+      <div scContextMenuTrigger>Right click here</div>
+    </div>
+  `,
+})
+class HostWithoutPortal {}
+
+function mount(type: typeof Host | typeof HostWithoutPortal) {
+  TestBed.configureTestingModule({});
+  const fixture = TestBed.createComponent(type);
+  fixture.detectChanges();
+  return fixture;
+}
+
+function target(fixture: { nativeElement: unknown }): HTMLElement {
+  const el = (fixture.nativeElement as HTMLElement).querySelector(
+    '[scContextMenu]',
+  );
+  if (!el) throw new Error('no context menu rendered');
+  return el as HTMLElement;
+}
+
+describe('ScContextMenu', () => {
+  it('renders without a runtime error', () => {
+    expect(() => mount(Host)).not.toThrow();
+  });
+
+  it('renders even when no menu portal is projected', () => {
+    // A required contentChild threw NG0951 here.
+    expect(() => mount(HostWithoutPortal)).not.toThrow();
+  });
+
+  it('suppresses the native menu on right-click', () => {
+    const fixture = mount(Host);
+    const event = new MouseEvent('contextmenu', {
+      bubbles: true,
+      cancelable: true,
+      clientX: 40,
+      clientY: 60,
+    });
+
+    target(fixture).dispatchEvent(event);
+    fixture.detectChanges();
+
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('anchors its hidden trigger at the pointer', () => {
+    const fixture = mount(Host);
+    target(fixture).dispatchEvent(
+      new MouseEvent('contextmenu', {
+        bubbles: true,
+        cancelable: true,
+        clientX: 40,
+        clientY: 60,
+      }),
+    );
+    fixture.detectChanges();
+
+    const anchor = (
+      fixture.nativeElement as HTMLElement
+    ).querySelector<HTMLElement>('[scMenuTrigger]');
+    expect(anchor?.style.left).toBe('40px');
+    expect(anchor?.style.top).toBe('60px');
+  });
+});

--- a/apps/showcase/src/app/pages/docs/context-menu/demos/context-menu-aria-demo-container.ts
+++ b/apps/showcase/src/app/pages/docs/context-menu/demos/context-menu-aria-demo-container.ts
@@ -42,45 +42,47 @@ import {
     <div scContextMenu class="h-[150px] w-[300px]">
       <div scContextMenuTrigger>Right click here</div>
 
-      <div scMenu>
-        <ng-template scMenuContent>
-          <div scMenuItem value="Back">
-            <span class="flex-1">Back</span>
-            <span class="text-muted-foreground ml-auto text-xs">⌘[</span>
-          </div>
-          <div scMenuItem value="Forward" [disabled]="true">
-            <span class="flex-1">Forward</span>
-            <span class="text-muted-foreground ml-auto text-xs">⌘]</span>
-          </div>
-          <div scMenuItem value="Reload">
-            <span class="flex-1">Reload</span>
-            <span class="text-muted-foreground ml-auto text-xs">⌘R</span>
-          </div>
+      <ng-template scMenuPortal>
+        <div scMenu>
+          <ng-template scMenuContent>
+            <div scMenuItem value="Back">
+              <span class="flex-1">Back</span>
+              <span class="text-muted-foreground ml-auto text-xs">⌘[</span>
+            </div>
+            <div scMenuItem value="Forward" [disabled]="true">
+              <span class="flex-1">Forward</span>
+              <span class="text-muted-foreground ml-auto text-xs">⌘]</span>
+            </div>
+            <div scMenuItem value="Reload">
+              <span class="flex-1">Reload</span>
+              <span class="text-muted-foreground ml-auto text-xs">⌘R</span>
+            </div>
 
-          <div scMenuSeparator></div>
+            <div scMenuSeparator></div>
 
-          <div scMenuItem value="Save Page As">
-            <span class="flex-1">Save Page As...</span>
-            <span class="text-muted-foreground ml-auto text-xs">⇧⌘S</span>
-          </div>
-          <div scMenuItem value="Create Shortcut">
-            <span class="flex-1">Create Shortcut...</span>
-          </div>
-          <div scMenuItem value="Name Window">
-            <span class="flex-1">Name Window...</span>
-          </div>
+            <div scMenuItem value="Save Page As">
+              <span class="flex-1">Save Page As...</span>
+              <span class="text-muted-foreground ml-auto text-xs">⇧⌘S</span>
+            </div>
+            <div scMenuItem value="Create Shortcut">
+              <span class="flex-1">Create Shortcut...</span>
+            </div>
+            <div scMenuItem value="Name Window">
+              <span class="flex-1">Name Window...</span>
+            </div>
 
-          <div scMenuSeparator></div>
+            <div scMenuSeparator></div>
 
-          <div scMenuItem value="Show Bookmarks Bar">
-            <span class="flex-1">Show Bookmarks Bar</span>
-            <span class="text-muted-foreground ml-auto text-xs">⇧⌘B</span>
-          </div>
-          <div scMenuItem value="Show Full URLs">
-            <span class="flex-1">Show Full URLs</span>
-          </div>
-        </ng-template>
-      </div>
+            <div scMenuItem value="Show Bookmarks Bar">
+              <span class="flex-1">Show Bookmarks Bar</span>
+              <span class="text-muted-foreground ml-auto text-xs">⇧⌘B</span>
+            </div>
+            <div scMenuItem value="Show Full URLs">
+              <span class="flex-1">Show Full URLs</span>
+            </div>
+          </ng-template>
+        </div>
+      </ng-template>
     </div>
   \`,
   host: { class: 'flex w-full justify-center' },

--- a/apps/showcase/src/app/pages/docs/context-menu/demos/context-menu-aria-demo.ts
+++ b/apps/showcase/src/app/pages/docs/context-menu/demos/context-menu-aria-demo.ts
@@ -22,45 +22,47 @@ import {
     <div scContextMenu class="h-[150px] w-[300px]">
       <div scContextMenuTrigger>Right click here</div>
 
-      <div scMenu>
-        <ng-template scMenuContent>
-          <div scMenuItem value="Back">
-            <span class="flex-1">Back</span>
-            <span class="text-muted-foreground ml-auto text-xs">⌘[</span>
-          </div>
-          <div scMenuItem value="Forward" [disabled]="true">
-            <span class="flex-1">Forward</span>
-            <span class="text-muted-foreground ml-auto text-xs">⌘]</span>
-          </div>
-          <div scMenuItem value="Reload">
-            <span class="flex-1">Reload</span>
-            <span class="text-muted-foreground ml-auto text-xs">⌘R</span>
-          </div>
+      <ng-template scMenuPortal>
+        <div scMenu>
+          <ng-template scMenuContent>
+            <div scMenuItem value="Back">
+              <span class="flex-1">Back</span>
+              <span class="text-muted-foreground ml-auto text-xs">⌘[</span>
+            </div>
+            <div scMenuItem value="Forward" [disabled]="true">
+              <span class="flex-1">Forward</span>
+              <span class="text-muted-foreground ml-auto text-xs">⌘]</span>
+            </div>
+            <div scMenuItem value="Reload">
+              <span class="flex-1">Reload</span>
+              <span class="text-muted-foreground ml-auto text-xs">⌘R</span>
+            </div>
 
-          <div scMenuSeparator></div>
+            <div scMenuSeparator></div>
 
-          <div scMenuItem value="Save Page As">
-            <span class="flex-1">Save Page As...</span>
-            <span class="text-muted-foreground ml-auto text-xs">⇧⌘S</span>
-          </div>
-          <div scMenuItem value="Create Shortcut">
-            <span class="flex-1">Create Shortcut...</span>
-          </div>
-          <div scMenuItem value="Name Window">
-            <span class="flex-1">Name Window...</span>
-          </div>
+            <div scMenuItem value="Save Page As">
+              <span class="flex-1">Save Page As...</span>
+              <span class="text-muted-foreground ml-auto text-xs">⇧⌘S</span>
+            </div>
+            <div scMenuItem value="Create Shortcut">
+              <span class="flex-1">Create Shortcut...</span>
+            </div>
+            <div scMenuItem value="Name Window">
+              <span class="flex-1">Name Window...</span>
+            </div>
 
-          <div scMenuSeparator></div>
+            <div scMenuSeparator></div>
 
-          <div scMenuItem value="Show Bookmarks Bar">
-            <span class="flex-1">Show Bookmarks Bar</span>
-            <span class="text-muted-foreground ml-auto text-xs">⇧⌘B</span>
-          </div>
-          <div scMenuItem value="Show Full URLs">
-            <span class="flex-1">Show Full URLs</span>
-          </div>
-        </ng-template>
-      </div>
+            <div scMenuItem value="Show Bookmarks Bar">
+              <span class="flex-1">Show Bookmarks Bar</span>
+              <span class="text-muted-foreground ml-auto text-xs">⇧⌘B</span>
+            </div>
+            <div scMenuItem value="Show Full URLs">
+              <span class="flex-1">Show Full URLs</span>
+            </div>
+          </ng-template>
+        </div>
+      </ng-template>
     </div>
   `,
   host: { class: 'flex w-full justify-center' },

--- a/apps/showcase/src/app/pages/docs/context-menu/demos/context-menu-demo-container.ts
+++ b/apps/showcase/src/app/pages/docs/context-menu/demos/context-menu-demo-container.ts
@@ -46,61 +46,63 @@ import { SiChevronRightIcon } from '@semantic-icons/lucide-icons';
     <div scContextMenu class="h-[150px] w-[300px]">
       <div scContextMenuTrigger>Right click here</div>
 
-      <div scMenu>
-        <ng-template scMenuContent>
-          <div scMenuItem value="Back">
-            <span class="flex-1">Back</span>
-            <span class="text-muted-foreground ml-auto text-xs">⌘[</span>
-          </div>
-          <div scMenuItem value="Forward" [disabled]="true">
-            <span class="flex-1">Forward</span>
-            <span class="text-muted-foreground ml-auto text-xs">⌘]</span>
-          </div>
-          <div scMenuItem value="Reload">
-            <span class="flex-1">Reload</span>
-            <span class="text-muted-foreground ml-auto text-xs">⌘R</span>
-          </div>
+      <ng-template scMenuPortal>
+        <div scMenu>
+          <ng-template scMenuContent>
+            <div scMenuItem value="Back">
+              <span class="flex-1">Back</span>
+              <span class="text-muted-foreground ml-auto text-xs">⌘[</span>
+            </div>
+            <div scMenuItem value="Forward" [disabled]="true">
+              <span class="flex-1">Forward</span>
+              <span class="text-muted-foreground ml-auto text-xs">⌘]</span>
+            </div>
+            <div scMenuItem value="Reload">
+              <span class="flex-1">Reload</span>
+              <span class="text-muted-foreground ml-auto text-xs">⌘R</span>
+            </div>
 
-          <div scMenuSeparator></div>
+            <div scMenuSeparator></div>
 
-          <div scMenuItem value="More Tools">
-            <span class="flex-1">More Tools</span>
-            <svg siChevronRightIcon class="ml-auto size-4"></svg>
-            <ng-template scMenuPortal>
-              <div scMenu>
-                <ng-template scMenuContent>
-                  <div scMenuItem value="Save Page As">
-                    <span class="flex-1">Save Page As...</span>
-                    <span class="text-muted-foreground ml-auto text-xs">
-                      ⇧⌘S
-                    </span>
-                  </div>
-                  <div scMenuItem value="Create Shortcut">
-                    <span class="flex-1">Create Shortcut...</span>
-                  </div>
-                  <div scMenuItem value="Name Window">
-                    <span class="flex-1">Name Window...</span>
-                  </div>
-                  <div scMenuSeparator></div>
-                  <div scMenuItem value="Developer Tools">
-                    <span class="flex-1">Developer Tools</span>
-                  </div>
-                </ng-template>
-              </div>
-            </ng-template>
-          </div>
+            <div scMenuItem value="More Tools">
+              <span class="flex-1">More Tools</span>
+              <svg siChevronRightIcon class="ml-auto size-4"></svg>
+              <ng-template scMenuPortal>
+                <div scMenu>
+                  <ng-template scMenuContent>
+                    <div scMenuItem value="Save Page As">
+                      <span class="flex-1">Save Page As...</span>
+                      <span class="text-muted-foreground ml-auto text-xs">
+                        ⇧⌘S
+                      </span>
+                    </div>
+                    <div scMenuItem value="Create Shortcut">
+                      <span class="flex-1">Create Shortcut...</span>
+                    </div>
+                    <div scMenuItem value="Name Window">
+                      <span class="flex-1">Name Window...</span>
+                    </div>
+                    <div scMenuSeparator></div>
+                    <div scMenuItem value="Developer Tools">
+                      <span class="flex-1">Developer Tools</span>
+                    </div>
+                  </ng-template>
+                </div>
+              </ng-template>
+            </div>
 
-          <div scMenuSeparator></div>
+            <div scMenuSeparator></div>
 
-          <div scMenuItem value="Show Bookmarks Bar">
-            <span class="flex-1">Show Bookmarks Bar</span>
-            <span class="text-muted-foreground ml-auto text-xs">⇧⌘B</span>
-          </div>
-          <div scMenuItem value="Show Full URLs">
-            <span class="flex-1">Show Full URLs</span>
-          </div>
-        </ng-template>
-      </div>
+            <div scMenuItem value="Show Bookmarks Bar">
+              <span class="flex-1">Show Bookmarks Bar</span>
+              <span class="text-muted-foreground ml-auto text-xs">⇧⌘B</span>
+            </div>
+            <div scMenuItem value="Show Full URLs">
+              <span class="flex-1">Show Full URLs</span>
+            </div>
+          </ng-template>
+        </div>
+      </ng-template>
     </div>
   \`,
   host: { class: 'flex w-full justify-center' },

--- a/apps/showcase/src/app/pages/docs/context-menu/demos/context-menu-demo.ts
+++ b/apps/showcase/src/app/pages/docs/context-menu/demos/context-menu-demo.ts
@@ -26,61 +26,63 @@ import { SiChevronRightIcon } from '@semantic-icons/lucide-icons';
     <div scContextMenu class="h-[150px] w-[300px]">
       <div scContextMenuTrigger>Right click here</div>
 
-      <div scMenu>
-        <ng-template scMenuContent>
-          <div scMenuItem value="Back">
-            <span class="flex-1">Back</span>
-            <span class="text-muted-foreground ml-auto text-xs">⌘[</span>
-          </div>
-          <div scMenuItem value="Forward" [disabled]="true">
-            <span class="flex-1">Forward</span>
-            <span class="text-muted-foreground ml-auto text-xs">⌘]</span>
-          </div>
-          <div scMenuItem value="Reload">
-            <span class="flex-1">Reload</span>
-            <span class="text-muted-foreground ml-auto text-xs">⌘R</span>
-          </div>
+      <ng-template scMenuPortal>
+        <div scMenu>
+          <ng-template scMenuContent>
+            <div scMenuItem value="Back">
+              <span class="flex-1">Back</span>
+              <span class="text-muted-foreground ml-auto text-xs">⌘[</span>
+            </div>
+            <div scMenuItem value="Forward" [disabled]="true">
+              <span class="flex-1">Forward</span>
+              <span class="text-muted-foreground ml-auto text-xs">⌘]</span>
+            </div>
+            <div scMenuItem value="Reload">
+              <span class="flex-1">Reload</span>
+              <span class="text-muted-foreground ml-auto text-xs">⌘R</span>
+            </div>
 
-          <div scMenuSeparator></div>
+            <div scMenuSeparator></div>
 
-          <div scMenuItem value="More Tools">
-            <span class="flex-1">More Tools</span>
-            <svg siChevronRightIcon class="ml-auto size-4"></svg>
-            <ng-template scMenuPortal>
-              <div scMenu>
-                <ng-template scMenuContent>
-                  <div scMenuItem value="Save Page As">
-                    <span class="flex-1">Save Page As...</span>
-                    <span class="text-muted-foreground ml-auto text-xs">
-                      ⇧⌘S
-                    </span>
-                  </div>
-                  <div scMenuItem value="Create Shortcut">
-                    <span class="flex-1">Create Shortcut...</span>
-                  </div>
-                  <div scMenuItem value="Name Window">
-                    <span class="flex-1">Name Window...</span>
-                  </div>
-                  <div scMenuSeparator></div>
-                  <div scMenuItem value="Developer Tools">
-                    <span class="flex-1">Developer Tools</span>
-                  </div>
-                </ng-template>
-              </div>
-            </ng-template>
-          </div>
+            <div scMenuItem value="More Tools">
+              <span class="flex-1">More Tools</span>
+              <svg siChevronRightIcon class="ml-auto size-4"></svg>
+              <ng-template scMenuPortal>
+                <div scMenu>
+                  <ng-template scMenuContent>
+                    <div scMenuItem value="Save Page As">
+                      <span class="flex-1">Save Page As...</span>
+                      <span class="text-muted-foreground ml-auto text-xs">
+                        ⇧⌘S
+                      </span>
+                    </div>
+                    <div scMenuItem value="Create Shortcut">
+                      <span class="flex-1">Create Shortcut...</span>
+                    </div>
+                    <div scMenuItem value="Name Window">
+                      <span class="flex-1">Name Window...</span>
+                    </div>
+                    <div scMenuSeparator></div>
+                    <div scMenuItem value="Developer Tools">
+                      <span class="flex-1">Developer Tools</span>
+                    </div>
+                  </ng-template>
+                </div>
+              </ng-template>
+            </div>
 
-          <div scMenuSeparator></div>
+            <div scMenuSeparator></div>
 
-          <div scMenuItem value="Show Bookmarks Bar">
-            <span class="flex-1">Show Bookmarks Bar</span>
-            <span class="text-muted-foreground ml-auto text-xs">⇧⌘B</span>
-          </div>
-          <div scMenuItem value="Show Full URLs">
-            <span class="flex-1">Show Full URLs</span>
-          </div>
-        </ng-template>
-      </div>
+            <div scMenuItem value="Show Bookmarks Bar">
+              <span class="flex-1">Show Bookmarks Bar</span>
+              <span class="text-muted-foreground ml-auto text-xs">⇧⌘B</span>
+            </div>
+            <div scMenuItem value="Show Full URLs">
+              <span class="flex-1">Show Full URLs</span>
+            </div>
+          </ng-template>
+        </div>
+      </ng-template>
     </div>
   `,
   host: { class: 'flex w-full justify-center' },

--- a/libs/ui/src/lib/components/context-menu/context-menu.ts
+++ b/libs/ui/src/lib/components/context-menu/context-menu.ts
@@ -1,74 +1,115 @@
+import { OverlayModule } from '@angular/cdk/overlay';
+import { NgTemplateOutlet } from '@angular/common';
 import {
   Component,
-  ElementRef,
   ViewEncapsulation,
   computed,
   contentChild,
-  inject,
+  effect,
   input,
+  signal,
+  viewChild,
 } from '@angular/core';
-import { cn } from '../../utils';
-import { ScMenu } from '../menu';
-import { ScContextMenuTrigger } from './context-menu-trigger';
+import { SIGNAL, signalSetFn } from '@angular/core/primitives/signals';
+import { buildOverlayPositionsWithFallback, cn } from '../../utils';
+import { ScMenuPortal } from '../menu/menu-portal';
+import { ScMenuTrigger } from '../menu/menu-trigger';
 
 @Component({
   selector: 'div[scContextMenu]',
+  imports: [OverlayModule, NgTemplateOutlet, ScMenuTrigger],
   template: `
     <ng-content />
-  `,
-  styles: `
-    [data-slot='context-menu'] > [data-slot='menu'] {
-      visibility: hidden;
-      position: fixed;
+
+    <!--
+      The overlay anchors to this element rather than to the pointer itself, so
+      the CDK still handles flipping and clamping near the viewport edges.
+      Moving it is all that positions the menu.
+    -->
+    <div
+      scMenuTrigger
+      class="pointer-events-none invisible fixed"
+      [style.left.px]="position().x"
+      [style.top.px]="position().y"
+    ></div>
+
+    @if (origin(); as origin) {
+      @if (menuPortal(); as portal) {
+        <ng-template
+          [cdkConnectedOverlayOpen]="expanded()"
+          [cdkConnectedOverlay]="{
+            origin,
+            usePopover: 'inline',
+            hasBackdrop: true,
+            backdropClass: 'cdk-overlay-transparent-backdrop',
+          }"
+          [cdkConnectedOverlayPositions]="positions()"
+          (backdropClick)="close()"
+          (overlayKeydown)="onOverlayKeydown($event)"
+          cdkAttachPopoverAsChild
+        >
+          <ng-container [ngTemplateOutlet]="portal.templateRef" />
+        </ng-template>
+      }
     }
   `,
   host: {
     'data-slot': 'context-menu',
     '[class]': 'class()',
     '(contextmenu)': 'onContextMenu($event)',
-    '(focusout)': 'onFocusOut($event)',
   },
   encapsulation: ViewEncapsulation.None,
 })
 export class ScContextMenu {
   readonly classInput = input<string>('', { alias: 'class' });
 
-  private readonly elementRef = inject(ElementRef<HTMLElement>);
-  private readonly trigger = contentChild(ScContextMenuTrigger);
-  private readonly scMenu = contentChild(ScMenu);
+  private readonly cursorTrigger = viewChild(ScMenuTrigger);
+  protected readonly menuPortal = contentChild(ScMenuPortal);
+
+  /** Viewport coordinates of the last right-click. */
+  protected readonly position = signal({ x: 0, y: 0 });
+
+  protected readonly origin = computed(
+    () => this.cursorTrigger()?.overlayOrigin,
+  );
+
+  protected readonly expanded = computed(
+    () => this.cursorTrigger()?.trigger?.expanded() ?? false,
+  );
+
+  protected readonly positions = computed(() =>
+    buildOverlayPositionsWithFallback('bottom', 'start', 0),
+  );
 
   protected readonly class = computed(() => cn('block', this.classInput()));
 
-  onContextMenu(event: MouseEvent) {
-    const triggerEl = this.trigger();
-    if (!triggerEl) {
-      return;
-    }
-
-    event.preventDefault();
-
-    const menu = this.scMenu()?.menu;
-    if (!menu) {
-      return;
-    }
-
-    menu._pattern.closeAll();
-    menu.element.style.visibility = 'visible';
-    menu.element.style.top = `${event.clientY}px`;
-    menu.element.style.left = `${event.clientX}px`;
-    setTimeout(() => menu._pattern.first());
+  constructor() {
+    // Same wiring ScMenuProvider does: hand the portal's menu to the trigger.
+    effect(() => {
+      const trigger = this.cursorTrigger()?.trigger;
+      const menu = this.menuPortal()?.menu();
+      if (trigger && menu) {
+        signalSetFn(trigger.menu[SIGNAL], menu);
+      }
+    });
   }
 
-  onFocusOut(event: FocusEvent) {
-    const menu = this.scMenu()?.menu;
-    if (!menu) {
-      return;
-    }
+  protected onContextMenu(event: MouseEvent): void {
+    event.preventDefault();
+    this.position.set({ x: event.clientX, y: event.clientY });
+    this.cursorTrigger()?.trigger?.open();
+  }
 
-    const relatedTarget = event.relatedTarget as HTMLElement | null;
-    if (!this.elementRef.nativeElement.contains(relatedTarget)) {
-      menu.close();
-      menu.element.style.visibility = 'hidden';
+  protected onOverlayKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Escape') {
+      this.close();
+    }
+  }
+
+  protected close(): void {
+    const trigger = this.cursorTrigger()?.trigger;
+    if (trigger?.expanded()) {
+      trigger.close();
     }
   }
 }


### PR DESCRIPTION
Rewrites `ScContextMenu` to follow the Angular Aria context-menu pattern instead of positioning the menu by hand.

## What was wrong

The menu was an inline sibling hidden with `visibility`, and right-clicking reached into `menu._pattern` to close and focus, then wrote `style.top`/`style.left` from the pointer coordinates. That meant:

- **The menu ran off-screen** near a viewport edge — nothing clamped or flipped it
- **No way to dismiss it** except moving focus away; Escape did nothing
- It depended on `_pattern`, an underscore-prefixed API

## What it does now

A hidden fixed-position element is moved to the pointer and **the overlay anchors to that element**, so the CDK handles flipping and clamping. That's the trick from your sample, and it's what lets a context menu reuse the ordinary connected-overlay machinery.

Opening and closing go through `MenuTrigger`'s `open()`, `close()` and `expanded()` — the same public API `ScMenuTrigger` already wraps for the rest of the menu family. A transparent backdrop closes on outside click; Escape closes via `overlayKeydown`.

## Breaking change to the template

The menu must now be projected inside `<ng-template scMenuPortal>`, matching how `ScMenuProvider` consumes it:

```html
<div scContextMenu>
  <div scContextMenuTrigger>Right click here</div>
  <ng-template scMenuPortal>
    <div scMenu>…</div>
  </ng-template>
</div>
```

Both demos are updated.

## The NG0951 you hit

Caused by `contentChild.required(ScMenuPortal)` — it throws when no portal is projected. `viewChild.required` has the same problem before the view resolves. Both are optional now and guarded.

**Four tests added, one reproducing that error exactly** — reverting the query to `required` fails it with the same `NG0951`.

## What I could not verify

The e2e suite doesn't run in this environment: Playwright's chromium binary isn't installed, so all 243 specs fail at launch regardless of the change. That's what the `243 failed` I saw was — not a regression. CI installs the browser, so the context-menu a11y spec will genuinely exercise this there.

`nx run-many -t lint` exits 0; `tsc --noEmit` clean; `validate-demo-code` 0 mismatches; 60/60 unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)