### PR TITLE
refactor(context-menu): rename ScContextMenu to ScContextMenuProvider

### DIFF
--- a/apps/showcase/src/app/pages/docs/context-menu/demos/context-menu-aria-demo-container.ts
+++ b/apps/showcase/src/app/pages/docs/context-menu/demos/context-menu-aria-demo-container.ts
@@ -20,7 +20,7 @@ import { ContextMenuAriaDemo } from './context-menu-aria-demo';
 export class ContextMenuAriaDemoContainer {
   readonly code = `import { Component, ViewEncapsulation } from '@angular/core';
 import {
-  ScContextMenu,
+  ScContextMenuProvider,
   ScContextMenuTrigger,
   ScMenu,
   ScMenuContent,
@@ -31,7 +31,7 @@ import {
 @Component({
   selector: 'app-context-menu-aria-demo',
   imports: [
-    ScContextMenu,
+    ScContextMenuProvider,
     ScContextMenuTrigger,
     ScMenu,
     ScMenuContent,
@@ -39,7 +39,7 @@ import {
     ScMenuSeparator,
   ],
   template: \`
-    <div scContextMenu class="h-[150px] w-[300px]">
+    <div scContextMenuProvider class="h-[150px] w-[300px]">
       <div scContextMenuTrigger>Right click here</div>
 
       <div scMenu>

--- a/apps/showcase/src/app/pages/docs/context-menu/demos/context-menu-aria-demo.ts
+++ b/apps/showcase/src/app/pages/docs/context-menu/demos/context-menu-aria-demo.ts
@@ -1,6 +1,6 @@
 import { Component, ViewEncapsulation } from '@angular/core';
 import {
-  ScContextMenu,
+  ScContextMenuProvider,
   ScContextMenuTrigger,
   ScMenu,
   ScMenuContent,
@@ -11,7 +11,7 @@ import {
 @Component({
   selector: 'app-context-menu-aria-demo',
   imports: [
-    ScContextMenu,
+    ScContextMenuProvider,
     ScContextMenuTrigger,
     ScMenu,
     ScMenuContent,
@@ -19,7 +19,7 @@ import {
     ScMenuSeparator,
   ],
   template: `
-    <div scContextMenu class="h-[150px] w-[300px]">
+    <div scContextMenuProvider class="h-[150px] w-[300px]">
       <div scContextMenuTrigger>Right click here</div>
 
       <div scMenu>

--- a/apps/showcase/src/app/pages/docs/context-menu/demos/context-menu-demo-container.ts
+++ b/apps/showcase/src/app/pages/docs/context-menu/demos/context-menu-demo-container.ts
@@ -20,7 +20,7 @@ import { ScContextMenuDemo } from './context-menu-demo';
 export class ScContextMenuDemoContainer {
   readonly code = `import { Component, ViewEncapsulation } from '@angular/core';
 import {
-  ScContextMenu,
+  ScContextMenuProvider,
   ScContextMenuTrigger,
   ScMenu,
   ScMenuContent,
@@ -33,7 +33,7 @@ import { SiChevronRightIcon } from '@semantic-icons/lucide-icons';
 @Component({
   selector: 'app-context-menu-demo',
   imports: [
-    ScContextMenu,
+    ScContextMenuProvider,
     ScContextMenuTrigger,
     ScMenu,
     ScMenuContent,
@@ -43,7 +43,7 @@ import { SiChevronRightIcon } from '@semantic-icons/lucide-icons';
     SiChevronRightIcon,
   ],
   template: \`
-    <div scContextMenu class="h-[150px] w-[300px]">
+    <div scContextMenuProvider class="h-[150px] w-[300px]">
       <div scContextMenuTrigger>Right click here</div>
 
       <div scMenu>

--- a/apps/showcase/src/app/pages/docs/context-menu/demos/context-menu-demo.ts
+++ b/apps/showcase/src/app/pages/docs/context-menu/demos/context-menu-demo.ts
@@ -1,6 +1,6 @@
 import { Component, ViewEncapsulation } from '@angular/core';
 import {
-  ScContextMenu,
+  ScContextMenuProvider,
   ScContextMenuTrigger,
   ScMenu,
   ScMenuContent,
@@ -13,7 +13,7 @@ import { SiChevronRightIcon } from '@semantic-icons/lucide-icons';
 @Component({
   selector: 'app-context-menu-demo',
   imports: [
-    ScContextMenu,
+    ScContextMenuProvider,
     ScContextMenuTrigger,
     ScMenu,
     ScMenuContent,
@@ -23,7 +23,7 @@ import { SiChevronRightIcon } from '@semantic-icons/lucide-icons';
     SiChevronRightIcon,
   ],
   template: `
-    <div scContextMenu class="h-[150px] w-[300px]">
+    <div scContextMenuProvider class="h-[150px] w-[300px]">
       <div scContextMenuTrigger>Right click here</div>
 
       <div scMenu>

--- a/libs/ui/src/lib/components/context-menu/README.md
+++ b/libs/ui/src/lib/components/context-menu/README.md
@@ -5,11 +5,11 @@ A right-click context menu built on top of the `ScMenu` component, positioned at
 ## Usage
 
 ```typescript
-import { ScContextMenu, ScContextMenuTrigger, ScMenu, ScMenuContent, ScMenuItem, ScMenuSeparator } from '@semantic-components/ui';
+import { ScContextMenuProvider, ScContextMenuTrigger, ScMenu, ScMenuContent, ScMenuItem, ScMenuSeparator } from '@semantic-components/ui';
 ```
 
 ```html
-<div scContextMenu class="h-[150px] w-[300px]">
+<div scContextMenuProvider class="h-[150px] w-[300px]">
   <div scContextMenuTrigger>Right click here</div>
 
   <div scMenu>
@@ -24,14 +24,14 @@ import { ScContextMenu, ScContextMenuTrigger, ScMenu, ScMenuContent, ScMenuItem,
 
 ## Components
 
-### ScContextMenu
+### ScContextMenuProvider
 
 Container component that listens for right-click events and manages the menu lifecycle.
 
-| Property | Type                 | Description                                        |
-| -------- | -------------------- | -------------------------------------------------- |
-| Selector | `div[scContextMenu]` | Must be placed on a `<div>` element.               |
-| `class`  | `input<string>`      | CSS classes merged with the default `block` class. |
+| Property | Type                         | Description                                        |
+| -------- | ---------------------------- | -------------------------------------------------- |
+| Selector | `div[scContextMenuProvider]` | Must be placed on a `<div>` element.               |
+| `class`  | `input<string>`              | CSS classes merged with the default `block` class. |
 
 **Data attributes:**
 
@@ -57,7 +57,7 @@ The context menu content uses the shared menu primitives (`ScMenu`, `ScMenuConte
 ### With keyboard shortcuts
 
 ```html
-<div scContextMenu class="h-[150px] w-[300px]">
+<div scContextMenuProvider class="h-[150px] w-[300px]">
   <div scContextMenuTrigger>Right click here</div>
 
   <div scMenu>

--- a/libs/ui/src/lib/components/context-menu/context-menu-provider.ts
+++ b/libs/ui/src/lib/components/context-menu/context-menu-provider.ts
@@ -12,25 +12,25 @@ import { ScMenu } from '../menu';
 import { ScContextMenuTrigger } from './context-menu-trigger';
 
 @Component({
-  selector: 'div[scContextMenu]',
+  selector: 'div[scContextMenuProvider]',
   template: `
     <ng-content />
   `,
   styles: `
-    [data-slot='context-menu'] > [data-slot='menu'] {
+    [data-slot='context-menu-provider'] > [data-slot='menu'] {
       visibility: hidden;
       position: fixed;
     }
   `,
   host: {
-    'data-slot': 'context-menu',
+    'data-slot': 'context-menu-provider',
     '[class]': 'class()',
     '(contextmenu)': 'onContextMenu($event)',
     '(focusout)': 'onFocusOut($event)',
   },
   encapsulation: ViewEncapsulation.None,
 })
-export class ScContextMenu {
+export class ScContextMenuProvider {
   readonly classInput = input<string>('', { alias: 'class' });
 
   private readonly elementRef = inject(ElementRef<HTMLElement>);

--- a/libs/ui/src/lib/components/context-menu/index.ts
+++ b/libs/ui/src/lib/components/context-menu/index.ts
@@ -1,2 +1,2 @@
-export { ScContextMenu } from './context-menu';
+export { ScContextMenuProvider } from './context-menu-provider';
 export { ScContextMenuTrigger } from './context-menu-trigger';


### PR DESCRIPTION
Step one of splitting the context menu in two. **Rename only — no behaviour changes.**

Frees the `ScContextMenu` name for a component that will own the hidden cursor anchor and the overlay, leaving this one as the wrapper that catches the right-click. The same split `ScMenuProvider` already uses for the regular menu.

| | |
|---|---|
| File | `context-menu.ts` → `context-menu-provider.ts` (tracked as a rename) |
| Class | `ScContextMenu` → `ScContextMenuProvider` |
| Selector | `div[scContextMenu]` → `div[scContextMenuProvider]` |

The barrel, README and both demos follow; the container `code` strings were regenerated with `sync-demo-code` rather than hand-edited.

## One judgement call

`data-slot` moves too, from `context-menu` to `context-menu-provider`, and the component's own `styles` selector follows. Otherwise a class called `ScContextMenuProvider` would emit `data-slot="context-menu"` and collide with the component about to reuse that name. Easy to revert if you'd rather it kept the old slot.

## Verification

`nx test showcase` 56/56 (this also runs the Angular compiler, which is what catches template and host-binding errors that `tsc --noEmit` misses); `nx run-many -t lint` exits 0; `validate-demo-code` 0 mismatches.

Step two — the new `ScContextMenu` wrapping the hidden `scMenuTrigger` and the `cdkConnectedOverlay` — follows separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)