### PR TITLE
feat(context-menu): move the menu into a CDK overlay

### DIFF
--- a/apps/showcase/src/app/pages/docs/context-menu/demos/context-menu-aria-demo-container.ts
+++ b/apps/showcase/src/app/pages/docs/context-menu/demos/context-menu-aria-demo-container.ts
@@ -20,6 +20,7 @@ import { ContextMenuAriaDemo } from './context-menu-aria-demo';
 export class ContextMenuAriaDemoContainer {
   readonly code = `import { Component, ViewEncapsulation } from '@angular/core';
 import {
+  ScContextMenu,
   ScContextMenuProvider,
   ScContextMenuTrigger,
   ScMenu,
@@ -31,6 +32,7 @@ import {
 @Component({
   selector: 'app-context-menu-aria-demo',
   imports: [
+    ScContextMenu,
     ScContextMenuProvider,
     ScContextMenuTrigger,
     ScMenu,
@@ -42,44 +44,46 @@ import {
     <div scContextMenuProvider class="h-[150px] w-[300px]">
       <div scContextMenuTrigger>Right click here</div>
 
-      <div scMenu>
-        <ng-template scMenuContent>
-          <div scMenuItem value="Back">
-            <span class="flex-1">Back</span>
-            <span class="text-muted-foreground ml-auto text-xs">⌘[</span>
-          </div>
-          <div scMenuItem value="Forward" [disabled]="true">
-            <span class="flex-1">Forward</span>
-            <span class="text-muted-foreground ml-auto text-xs">⌘]</span>
-          </div>
-          <div scMenuItem value="Reload">
-            <span class="flex-1">Reload</span>
-            <span class="text-muted-foreground ml-auto text-xs">⌘R</span>
-          </div>
+      <div scContextMenu>
+        <div scMenu>
+          <ng-template scMenuContent>
+            <div scMenuItem value="Back">
+              <span class="flex-1">Back</span>
+              <span class="text-muted-foreground ml-auto text-xs">⌘[</span>
+            </div>
+            <div scMenuItem value="Forward" [disabled]="true">
+              <span class="flex-1">Forward</span>
+              <span class="text-muted-foreground ml-auto text-xs">⌘]</span>
+            </div>
+            <div scMenuItem value="Reload">
+              <span class="flex-1">Reload</span>
+              <span class="text-muted-foreground ml-auto text-xs">⌘R</span>
+            </div>
 
-          <div scMenuSeparator></div>
+            <div scMenuSeparator></div>
 
-          <div scMenuItem value="Save Page As">
-            <span class="flex-1">Save Page As...</span>
-            <span class="text-muted-foreground ml-auto text-xs">⇧⌘S</span>
-          </div>
-          <div scMenuItem value="Create Shortcut">
-            <span class="flex-1">Create Shortcut...</span>
-          </div>
-          <div scMenuItem value="Name Window">
-            <span class="flex-1">Name Window...</span>
-          </div>
+            <div scMenuItem value="Save Page As">
+              <span class="flex-1">Save Page As...</span>
+              <span class="text-muted-foreground ml-auto text-xs">⇧⌘S</span>
+            </div>
+            <div scMenuItem value="Create Shortcut">
+              <span class="flex-1">Create Shortcut...</span>
+            </div>
+            <div scMenuItem value="Name Window">
+              <span class="flex-1">Name Window...</span>
+            </div>
 
-          <div scMenuSeparator></div>
+            <div scMenuSeparator></div>
 
-          <div scMenuItem value="Show Bookmarks Bar">
-            <span class="flex-1">Show Bookmarks Bar</span>
-            <span class="text-muted-foreground ml-auto text-xs">⇧⌘B</span>
-          </div>
-          <div scMenuItem value="Show Full URLs">
-            <span class="flex-1">Show Full URLs</span>
-          </div>
-        </ng-template>
+            <div scMenuItem value="Show Bookmarks Bar">
+              <span class="flex-1">Show Bookmarks Bar</span>
+              <span class="text-muted-foreground ml-auto text-xs">⇧⌘B</span>
+            </div>
+            <div scMenuItem value="Show Full URLs">
+              <span class="flex-1">Show Full URLs</span>
+            </div>
+          </ng-template>
+        </div>
       </div>
     </div>
   \`,

--- a/apps/showcase/src/app/pages/docs/context-menu/demos/context-menu-aria-demo.ts
+++ b/apps/showcase/src/app/pages/docs/context-menu/demos/context-menu-aria-demo.ts
@@ -1,5 +1,6 @@
 import { Component, ViewEncapsulation } from '@angular/core';
 import {
+  ScContextMenu,
   ScContextMenuProvider,
   ScContextMenuTrigger,
   ScMenu,
@@ -11,6 +12,7 @@ import {
 @Component({
   selector: 'app-context-menu-aria-demo',
   imports: [
+    ScContextMenu,
     ScContextMenuProvider,
     ScContextMenuTrigger,
     ScMenu,
@@ -22,44 +24,46 @@ import {
     <div scContextMenuProvider class="h-[150px] w-[300px]">
       <div scContextMenuTrigger>Right click here</div>
 
-      <div scMenu>
-        <ng-template scMenuContent>
-          <div scMenuItem value="Back">
-            <span class="flex-1">Back</span>
-            <span class="text-muted-foreground ml-auto text-xs">⌘[</span>
-          </div>
-          <div scMenuItem value="Forward" [disabled]="true">
-            <span class="flex-1">Forward</span>
-            <span class="text-muted-foreground ml-auto text-xs">⌘]</span>
-          </div>
-          <div scMenuItem value="Reload">
-            <span class="flex-1">Reload</span>
-            <span class="text-muted-foreground ml-auto text-xs">⌘R</span>
-          </div>
+      <div scContextMenu>
+        <div scMenu>
+          <ng-template scMenuContent>
+            <div scMenuItem value="Back">
+              <span class="flex-1">Back</span>
+              <span class="text-muted-foreground ml-auto text-xs">⌘[</span>
+            </div>
+            <div scMenuItem value="Forward" [disabled]="true">
+              <span class="flex-1">Forward</span>
+              <span class="text-muted-foreground ml-auto text-xs">⌘]</span>
+            </div>
+            <div scMenuItem value="Reload">
+              <span class="flex-1">Reload</span>
+              <span class="text-muted-foreground ml-auto text-xs">⌘R</span>
+            </div>
 
-          <div scMenuSeparator></div>
+            <div scMenuSeparator></div>
 
-          <div scMenuItem value="Save Page As">
-            <span class="flex-1">Save Page As...</span>
-            <span class="text-muted-foreground ml-auto text-xs">⇧⌘S</span>
-          </div>
-          <div scMenuItem value="Create Shortcut">
-            <span class="flex-1">Create Shortcut...</span>
-          </div>
-          <div scMenuItem value="Name Window">
-            <span class="flex-1">Name Window...</span>
-          </div>
+            <div scMenuItem value="Save Page As">
+              <span class="flex-1">Save Page As...</span>
+              <span class="text-muted-foreground ml-auto text-xs">⇧⌘S</span>
+            </div>
+            <div scMenuItem value="Create Shortcut">
+              <span class="flex-1">Create Shortcut...</span>
+            </div>
+            <div scMenuItem value="Name Window">
+              <span class="flex-1">Name Window...</span>
+            </div>
 
-          <div scMenuSeparator></div>
+            <div scMenuSeparator></div>
 
-          <div scMenuItem value="Show Bookmarks Bar">
-            <span class="flex-1">Show Bookmarks Bar</span>
-            <span class="text-muted-foreground ml-auto text-xs">⇧⌘B</span>
-          </div>
-          <div scMenuItem value="Show Full URLs">
-            <span class="flex-1">Show Full URLs</span>
-          </div>
-        </ng-template>
+            <div scMenuItem value="Show Bookmarks Bar">
+              <span class="flex-1">Show Bookmarks Bar</span>
+              <span class="text-muted-foreground ml-auto text-xs">⇧⌘B</span>
+            </div>
+            <div scMenuItem value="Show Full URLs">
+              <span class="flex-1">Show Full URLs</span>
+            </div>
+          </ng-template>
+        </div>
       </div>
     </div>
   `,

--- a/apps/showcase/src/app/pages/docs/context-menu/demos/context-menu-demo-container.ts
+++ b/apps/showcase/src/app/pages/docs/context-menu/demos/context-menu-demo-container.ts
@@ -20,6 +20,7 @@ import { ScContextMenuDemo } from './context-menu-demo';
 export class ScContextMenuDemoContainer {
   readonly code = `import { Component, ViewEncapsulation } from '@angular/core';
 import {
+  ScContextMenu,
   ScContextMenuProvider,
   ScContextMenuTrigger,
   ScMenu,
@@ -33,6 +34,7 @@ import { SiChevronRightIcon } from '@semantic-icons/lucide-icons';
 @Component({
   selector: 'app-context-menu-demo',
   imports: [
+    ScContextMenu,
     ScContextMenuProvider,
     ScContextMenuTrigger,
     ScMenu,
@@ -46,60 +48,62 @@ import { SiChevronRightIcon } from '@semantic-icons/lucide-icons';
     <div scContextMenuProvider class="h-[150px] w-[300px]">
       <div scContextMenuTrigger>Right click here</div>
 
-      <div scMenu>
-        <ng-template scMenuContent>
-          <div scMenuItem value="Back">
-            <span class="flex-1">Back</span>
-            <span class="text-muted-foreground ml-auto text-xs">⌘[</span>
-          </div>
-          <div scMenuItem value="Forward" [disabled]="true">
-            <span class="flex-1">Forward</span>
-            <span class="text-muted-foreground ml-auto text-xs">⌘]</span>
-          </div>
-          <div scMenuItem value="Reload">
-            <span class="flex-1">Reload</span>
-            <span class="text-muted-foreground ml-auto text-xs">⌘R</span>
-          </div>
+      <div scContextMenu>
+        <div scMenu>
+          <ng-template scMenuContent>
+            <div scMenuItem value="Back">
+              <span class="flex-1">Back</span>
+              <span class="text-muted-foreground ml-auto text-xs">⌘[</span>
+            </div>
+            <div scMenuItem value="Forward" [disabled]="true">
+              <span class="flex-1">Forward</span>
+              <span class="text-muted-foreground ml-auto text-xs">⌘]</span>
+            </div>
+            <div scMenuItem value="Reload">
+              <span class="flex-1">Reload</span>
+              <span class="text-muted-foreground ml-auto text-xs">⌘R</span>
+            </div>
 
-          <div scMenuSeparator></div>
+            <div scMenuSeparator></div>
 
-          <div scMenuItem value="More Tools">
-            <span class="flex-1">More Tools</span>
-            <svg siChevronRightIcon class="ml-auto size-4"></svg>
-            <ng-template scMenuPortal>
-              <div scMenu>
-                <ng-template scMenuContent>
-                  <div scMenuItem value="Save Page As">
-                    <span class="flex-1">Save Page As...</span>
-                    <span class="text-muted-foreground ml-auto text-xs">
-                      ⇧⌘S
-                    </span>
-                  </div>
-                  <div scMenuItem value="Create Shortcut">
-                    <span class="flex-1">Create Shortcut...</span>
-                  </div>
-                  <div scMenuItem value="Name Window">
-                    <span class="flex-1">Name Window...</span>
-                  </div>
-                  <div scMenuSeparator></div>
-                  <div scMenuItem value="Developer Tools">
-                    <span class="flex-1">Developer Tools</span>
-                  </div>
-                </ng-template>
-              </div>
-            </ng-template>
-          </div>
+            <div scMenuItem value="More Tools">
+              <span class="flex-1">More Tools</span>
+              <svg siChevronRightIcon class="ml-auto size-4"></svg>
+              <ng-template scMenuPortal>
+                <div scMenu>
+                  <ng-template scMenuContent>
+                    <div scMenuItem value="Save Page As">
+                      <span class="flex-1">Save Page As...</span>
+                      <span class="text-muted-foreground ml-auto text-xs">
+                        ⇧⌘S
+                      </span>
+                    </div>
+                    <div scMenuItem value="Create Shortcut">
+                      <span class="flex-1">Create Shortcut...</span>
+                    </div>
+                    <div scMenuItem value="Name Window">
+                      <span class="flex-1">Name Window...</span>
+                    </div>
+                    <div scMenuSeparator></div>
+                    <div scMenuItem value="Developer Tools">
+                      <span class="flex-1">Developer Tools</span>
+                    </div>
+                  </ng-template>
+                </div>
+              </ng-template>
+            </div>
 
-          <div scMenuSeparator></div>
+            <div scMenuSeparator></div>
 
-          <div scMenuItem value="Show Bookmarks Bar">
-            <span class="flex-1">Show Bookmarks Bar</span>
-            <span class="text-muted-foreground ml-auto text-xs">⇧⌘B</span>
-          </div>
-          <div scMenuItem value="Show Full URLs">
-            <span class="flex-1">Show Full URLs</span>
-          </div>
-        </ng-template>
+            <div scMenuItem value="Show Bookmarks Bar">
+              <span class="flex-1">Show Bookmarks Bar</span>
+              <span class="text-muted-foreground ml-auto text-xs">⇧⌘B</span>
+            </div>
+            <div scMenuItem value="Show Full URLs">
+              <span class="flex-1">Show Full URLs</span>
+            </div>
+          </ng-template>
+        </div>
       </div>
     </div>
   \`,

--- a/apps/showcase/src/app/pages/docs/context-menu/demos/context-menu-demo.ts
+++ b/apps/showcase/src/app/pages/docs/context-menu/demos/context-menu-demo.ts
@@ -1,5 +1,6 @@
 import { Component, ViewEncapsulation } from '@angular/core';
 import {
+  ScContextMenu,
   ScContextMenuProvider,
   ScContextMenuTrigger,
   ScMenu,
@@ -13,6 +14,7 @@ import { SiChevronRightIcon } from '@semantic-icons/lucide-icons';
 @Component({
   selector: 'app-context-menu-demo',
   imports: [
+    ScContextMenu,
     ScContextMenuProvider,
     ScContextMenuTrigger,
     ScMenu,
@@ -26,60 +28,62 @@ import { SiChevronRightIcon } from '@semantic-icons/lucide-icons';
     <div scContextMenuProvider class="h-[150px] w-[300px]">
       <div scContextMenuTrigger>Right click here</div>
 
-      <div scMenu>
-        <ng-template scMenuContent>
-          <div scMenuItem value="Back">
-            <span class="flex-1">Back</span>
-            <span class="text-muted-foreground ml-auto text-xs">⌘[</span>
-          </div>
-          <div scMenuItem value="Forward" [disabled]="true">
-            <span class="flex-1">Forward</span>
-            <span class="text-muted-foreground ml-auto text-xs">⌘]</span>
-          </div>
-          <div scMenuItem value="Reload">
-            <span class="flex-1">Reload</span>
-            <span class="text-muted-foreground ml-auto text-xs">⌘R</span>
-          </div>
+      <div scContextMenu>
+        <div scMenu>
+          <ng-template scMenuContent>
+            <div scMenuItem value="Back">
+              <span class="flex-1">Back</span>
+              <span class="text-muted-foreground ml-auto text-xs">⌘[</span>
+            </div>
+            <div scMenuItem value="Forward" [disabled]="true">
+              <span class="flex-1">Forward</span>
+              <span class="text-muted-foreground ml-auto text-xs">⌘]</span>
+            </div>
+            <div scMenuItem value="Reload">
+              <span class="flex-1">Reload</span>
+              <span class="text-muted-foreground ml-auto text-xs">⌘R</span>
+            </div>
 
-          <div scMenuSeparator></div>
+            <div scMenuSeparator></div>
 
-          <div scMenuItem value="More Tools">
-            <span class="flex-1">More Tools</span>
-            <svg siChevronRightIcon class="ml-auto size-4"></svg>
-            <ng-template scMenuPortal>
-              <div scMenu>
-                <ng-template scMenuContent>
-                  <div scMenuItem value="Save Page As">
-                    <span class="flex-1">Save Page As...</span>
-                    <span class="text-muted-foreground ml-auto text-xs">
-                      ⇧⌘S
-                    </span>
-                  </div>
-                  <div scMenuItem value="Create Shortcut">
-                    <span class="flex-1">Create Shortcut...</span>
-                  </div>
-                  <div scMenuItem value="Name Window">
-                    <span class="flex-1">Name Window...</span>
-                  </div>
-                  <div scMenuSeparator></div>
-                  <div scMenuItem value="Developer Tools">
-                    <span class="flex-1">Developer Tools</span>
-                  </div>
-                </ng-template>
-              </div>
-            </ng-template>
-          </div>
+            <div scMenuItem value="More Tools">
+              <span class="flex-1">More Tools</span>
+              <svg siChevronRightIcon class="ml-auto size-4"></svg>
+              <ng-template scMenuPortal>
+                <div scMenu>
+                  <ng-template scMenuContent>
+                    <div scMenuItem value="Save Page As">
+                      <span class="flex-1">Save Page As...</span>
+                      <span class="text-muted-foreground ml-auto text-xs">
+                        ⇧⌘S
+                      </span>
+                    </div>
+                    <div scMenuItem value="Create Shortcut">
+                      <span class="flex-1">Create Shortcut...</span>
+                    </div>
+                    <div scMenuItem value="Name Window">
+                      <span class="flex-1">Name Window...</span>
+                    </div>
+                    <div scMenuSeparator></div>
+                    <div scMenuItem value="Developer Tools">
+                      <span class="flex-1">Developer Tools</span>
+                    </div>
+                  </ng-template>
+                </div>
+              </ng-template>
+            </div>
 
-          <div scMenuSeparator></div>
+            <div scMenuSeparator></div>
 
-          <div scMenuItem value="Show Bookmarks Bar">
-            <span class="flex-1">Show Bookmarks Bar</span>
-            <span class="text-muted-foreground ml-auto text-xs">⇧⌘B</span>
-          </div>
-          <div scMenuItem value="Show Full URLs">
-            <span class="flex-1">Show Full URLs</span>
-          </div>
-        </ng-template>
+            <div scMenuItem value="Show Bookmarks Bar">
+              <span class="flex-1">Show Bookmarks Bar</span>
+              <span class="text-muted-foreground ml-auto text-xs">⇧⌘B</span>
+            </div>
+            <div scMenuItem value="Show Full URLs">
+              <span class="flex-1">Show Full URLs</span>
+            </div>
+          </ng-template>
+        </div>
       </div>
     </div>
   `,

--- a/libs/ui/src/lib/components/context-menu/context-menu-provider.ts
+++ b/libs/ui/src/lib/components/context-menu/context-menu-provider.ts
@@ -1,74 +1,53 @@
 import {
   Component,
-  ElementRef,
   ViewEncapsulation,
   computed,
   contentChild,
-  inject,
   input,
+  signal,
 } from '@angular/core';
 import { cn } from '../../utils';
-import { ScMenu } from '../menu';
+import { ScContextMenu } from './context-menu';
 import { ScContextMenuTrigger } from './context-menu-trigger';
+import { SC_CONTEXT_MENU_PROVIDER } from './context-menu-types';
 
+/**
+ * Catches the right-click and records where it happened. ScContextMenu reads
+ * that position to park its anchor, and the overlay does the rest.
+ */
 @Component({
   selector: 'div[scContextMenuProvider]',
+  providers: [
+    { provide: SC_CONTEXT_MENU_PROVIDER, useExisting: ScContextMenuProvider },
+  ],
   template: `
     <ng-content />
-  `,
-  styles: `
-    [data-slot='context-menu-provider'] > [data-slot='menu'] {
-      visibility: hidden;
-      position: fixed;
-    }
   `,
   host: {
     'data-slot': 'context-menu-provider',
     '[class]': 'class()',
     '(contextmenu)': 'onContextMenu($event)',
-    '(focusout)': 'onFocusOut($event)',
   },
   encapsulation: ViewEncapsulation.None,
 })
 export class ScContextMenuProvider {
   readonly classInput = input<string>('', { alias: 'class' });
 
-  private readonly elementRef = inject(ElementRef<HTMLElement>);
   private readonly trigger = contentChild(ScContextMenuTrigger);
-  private readonly scMenu = contentChild(ScMenu);
+  private readonly contextMenu = contentChild(ScContextMenu);
+
+  /** Viewport coordinates of the last right-click. */
+  readonly position = signal({ x: 0, y: 0 });
 
   protected readonly class = computed(() => cn('block', this.classInput()));
 
-  onContextMenu(event: MouseEvent) {
-    const triggerEl = this.trigger();
-    if (!triggerEl) {
+  protected onContextMenu(event: MouseEvent): void {
+    if (!this.trigger()) {
       return;
     }
 
     event.preventDefault();
-
-    const menu = this.scMenu()?.menu;
-    if (!menu) {
-      return;
-    }
-
-    menu._pattern.closeAll();
-    menu.element.style.visibility = 'visible';
-    menu.element.style.top = `${event.clientY}px`;
-    menu.element.style.left = `${event.clientX}px`;
-    setTimeout(() => menu._pattern.first());
-  }
-
-  onFocusOut(event: FocusEvent) {
-    const menu = this.scMenu()?.menu;
-    if (!menu) {
-      return;
-    }
-
-    const relatedTarget = event.relatedTarget as HTMLElement | null;
-    if (!this.elementRef.nativeElement.contains(relatedTarget)) {
-      menu.close();
-      menu.element.style.visibility = 'hidden';
-    }
+    this.position.set({ x: event.clientX, y: event.clientY });
+    this.contextMenu()?.open();
   }
 }

--- a/libs/ui/src/lib/components/context-menu/context-menu-types.ts
+++ b/libs/ui/src/lib/components/context-menu/context-menu-types.ts
@@ -1,0 +1,9 @@
+import { InjectionToken } from '@angular/core';
+
+export interface ScContextMenuContext {
+  /** Viewport coordinates of the last right-click. */
+  position: () => { x: number; y: number };
+}
+
+export const SC_CONTEXT_MENU_PROVIDER =
+  new InjectionToken<ScContextMenuContext>('SC_CONTEXT_MENU_PROVIDER');

--- a/libs/ui/src/lib/components/context-menu/context-menu.ts
+++ b/libs/ui/src/lib/components/context-menu/context-menu.ts
@@ -1,0 +1,92 @@
+import { Menu, MenuTrigger } from '@angular/aria/menu';
+import { OverlayModule } from '@angular/cdk/overlay';
+import {
+  Component,
+  ViewEncapsulation,
+  computed,
+  contentChild,
+  inject,
+  input,
+  viewChild,
+} from '@angular/core';
+import { cn } from '../../utils';
+import { ScMenu } from '../menu';
+import { SC_CONTEXT_MENU_PROVIDER } from './context-menu-types';
+
+/**
+ * Holds the menu for a context menu: an anchor element parked at the pointer,
+ * and the overlay that positions the menu against it.
+ *
+ * The anchor exists because an overlay needs something to attach to, and a
+ * pointer is not an element. Moving it is what places the menu, and going
+ * through the overlay is what makes the menu flip near a viewport edge,
+ * dismiss on an outside click, and close on Escape.
+ */
+@Component({
+  selector: 'div[scContextMenu]',
+  imports: [MenuTrigger, OverlayModule],
+  template: `
+    <div
+      #triggerEl
+      ngMenuTrigger
+      #trigger="ngMenuTrigger"
+      [menu]="menu()"
+      style="position: fixed; visibility: hidden"
+      [style.left.px]="position().x"
+      [style.top.px]="position().y"
+    ></div>
+
+    <ng-template
+      [cdkConnectedOverlayOpen]="trigger.expanded()"
+      [cdkConnectedOverlay]="{
+        origin: triggerEl,
+        usePopover: 'inline',
+        hasBackdrop: true,
+        backdropClass: 'cdk-overlay-transparent-backdrop',
+      }"
+      (backdropClick)="close()"
+      (overlayKeydown)="onOverlayKeydown($event)"
+      cdkAttachPopoverAsChild
+    >
+      <ng-content />
+    </ng-template>
+  `,
+  host: {
+    'data-slot': 'context-menu',
+    '[class]': 'class()',
+  },
+  encapsulation: ViewEncapsulation.None,
+})
+export class ScContextMenu {
+  readonly classInput = input<string>('', { alias: 'class' });
+
+  private readonly provider = inject(SC_CONTEXT_MENU_PROVIDER);
+  private readonly cursorTrigger = viewChild(MenuTrigger);
+  private readonly scMenu = contentChild(ScMenu);
+
+  /** Where the provider last saw a right-click. */
+  protected readonly position = this.provider.position;
+
+  protected readonly menu = computed(
+    () => this.scMenu()?.menu as Menu<unknown> | undefined,
+  );
+
+  protected readonly class = computed(() => cn('contents', this.classInput()));
+
+  open(): void {
+    this.cursorTrigger()?.open();
+  }
+
+  close(): void {
+    const trigger = this.cursorTrigger();
+    if (trigger?.expanded()) {
+      trigger.close();
+    }
+  }
+
+  protected onOverlayKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Escape') {
+      this.close();
+    }
+  }
+}

--- a/libs/ui/src/lib/components/context-menu/index.ts
+++ b/libs/ui/src/lib/components/context-menu/index.ts
@@ -1,2 +1,4 @@
+export { ScContextMenu } from './context-menu';
 export { ScContextMenuProvider } from './context-menu-provider';
 export { ScContextMenuTrigger } from './context-menu-trigger';
+export * from './context-menu-types';


### PR DESCRIPTION
Step two, rebased onto `main` now that the rename (#1539) has landed.

**Replaces #1540**, which GitHub auto-closed when its base branch was deleted on merge — my sequencing error; I should have retargeted it to `main` first. Same commit, cherry-picked.

`ScContextMenu` owns what you pasted from the Aria demo: the anchor parked at the pointer, and the overlay that positions the menu against it. `ScContextMenuProvider` keeps only the right-click.

```html
<div scContextMenuProvider>
  <div scContextMenuTrigger>Right click here</div>

  <div scContextMenu>
    <div scMenu>
      <ng-template scMenuContent>…</ng-template>
    </div>
  </div>
</div>
```

## What the overlay buys

The old version wrote `clientX`/`clientY` straight to `left`/`top` and could only be closed by `focusout`. Now: the menu **flips near a viewport edge**, an **outside click dismisses** it via the transparent backdrop, and **Escape closes** it via `overlayKeydown`. The visibility-toggling `styles` block is gone — the overlay controls whether the menu exists.

## Implementation notes

**Aria's `ngMenuTrigger` directly**, not our `ScMenuTrigger` — that wrapper only adds a `CdkOverlayOrigin`, redundant when the element itself is the origin.

**Provider and menu talk through `SC_CONTEXT_MENU_PROVIDER`.** Injecting the class directly made the two files an import cycle: typechecks and bundles fine, fails at runtime with an undefined class. The token matches the `SC_CHECKBOX_FIELD` pattern already in the repo.

## Known, not addressed here

- **The menu blinks as it opens.** For one change-detection pass it exists before being handed to the trigger, reports `data-visible="false"`, and `ScMenu`'s `data-[visible=false]:hidden` pulls it out of flow. I had a fix — a scoped `sc-context-menu-pane` rule — which you reverted, so it's left out pending your call.
- **`cdkAttachPopoverAsChild` does nothing.** It doesn't exist in the installed CDK, so it's an unmatched attribute, silently ignored. Carried over from the Aria demo. Harmless, but worth dropping.

## Verification

`nx test showcase` 56/56; `nx run-many -t lint` exits 0; `validate-demo-code` 0 mismatches. The interactive behaviour still wants a manual try — e2e can't run here, as Playwright's chromium binary isn't installed in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)