### PR TITLE
fix(tabs): wrap tab panel content in scTabContent templates

### DIFF
--- a/apps/blocks/src/app/pages/gallery/gallery.page.ts
+++ b/apps/blocks/src/app/pages/gallery/gallery.page.ts
@@ -32,6 +32,7 @@ import {
   ScSpinner,
   ScSwitch,
   ScTab,
+  ScTabContent,
   ScTabList,
   ScTabPanel,
   ScTabs,
@@ -75,6 +76,7 @@ import {
     ScSpinner,
     ScSwitch,
     ScTab,
+    ScTabContent,
     ScTabList,
     ScTabPanel,
     ScTabs,
@@ -415,28 +417,34 @@ import {
                 <button scTab value="reports">Reports</button>
               </div>
               <div scTabPanel value="overview">
-                <div class="rounded-lg border p-4">
-                  <h3 class="text-lg font-medium">Overview</h3>
-                  <p class="text-muted-foreground text-sm">
-                    A high-level summary of your project's metrics.
-                  </p>
-                </div>
+                <ng-template scTabContent>
+                  <div class="rounded-lg border p-4">
+                    <h3 class="text-lg font-medium">Overview</h3>
+                    <p class="text-muted-foreground text-sm">
+                      A high-level summary of your project's metrics.
+                    </p>
+                  </div>
+                </ng-template>
               </div>
               <div scTabPanel value="analytics">
-                <div class="rounded-lg border p-4">
-                  <h3 class="text-lg font-medium">Analytics</h3>
-                  <p class="text-muted-foreground text-sm">
-                    Detailed analytics and performance data.
-                  </p>
-                </div>
+                <ng-template scTabContent>
+                  <div class="rounded-lg border p-4">
+                    <h3 class="text-lg font-medium">Analytics</h3>
+                    <p class="text-muted-foreground text-sm">
+                      Detailed analytics and performance data.
+                    </p>
+                  </div>
+                </ng-template>
               </div>
               <div scTabPanel value="reports">
-                <div class="rounded-lg border p-4">
-                  <h3 class="text-lg font-medium">Reports</h3>
-                  <p class="text-muted-foreground text-sm">
-                    Generated reports and exportable data.
-                  </p>
-                </div>
+                <ng-template scTabContent>
+                  <div class="rounded-lg border p-4">
+                    <h3 class="text-lg font-medium">Reports</h3>
+                    <p class="text-muted-foreground text-sm">
+                      Generated reports and exportable data.
+                    </p>
+                  </div>
+                </ng-template>
               </div>
             </div>
           </section>

--- a/apps/blocks/src/app/pages/settings/settings.page.ts
+++ b/apps/blocks/src/app/pages/settings/settings.page.ts
@@ -15,6 +15,7 @@ import {
   ScSwitch,
   ScSwitchField,
   ScTab,
+  ScTabContent,
   ScTabList,
   ScTabPanel,
   ScTabs,
@@ -39,6 +40,7 @@ import {
     ScSwitch,
     ScSwitchField,
     ScTab,
+    ScTabContent,
     ScTabList,
     ScTabPanel,
     ScTabs,
@@ -65,291 +67,301 @@ import {
           </div>
 
           <div scTabPanel value="profile">
-            <div class="space-y-6 pt-6">
-              <div scCard>
-                <div scCardHeader>
-                  <div class="flex items-center gap-4">
-                    <div
-                      class="bg-muted flex size-16 items-center justify-center rounded-full text-lg font-semibold"
-                    >
-                      JD
-                    </div>
-                    <div>
-                      <h3 scCardTitle>John Doe</h3>
-                      <p scCardDescription>john.doe&#64;example.com</p>
+            <ng-template scTabContent>
+              <div class="space-y-6 pt-6">
+                <div scCard>
+                  <div scCardHeader>
+                    <div class="flex items-center gap-4">
+                      <div
+                        class="bg-muted flex size-16 items-center justify-center rounded-full text-lg font-semibold"
+                      >
+                        JD
+                      </div>
+                      <div>
+                        <h3 scCardTitle>John Doe</h3>
+                        <p scCardDescription>john.doe&#64;example.com</p>
+                      </div>
                     </div>
                   </div>
                 </div>
-              </div>
 
-              <div scCard>
-                <div scCardHeader>
-                  <h3 scCardTitle>Profile Information</h3>
-                  <p scCardDescription>Update your profile details below.</p>
-                </div>
-                <div scCardBody>
-                  <div class="space-y-4">
-                    <div class="space-y-2">
-                      <label scLabel for="display-name">Display Name</label>
-                      <input
-                        scInput
-                        id="display-name"
-                        type="text"
-                        placeholder="John Doe"
-                      />
-                    </div>
-                    <div class="space-y-2">
-                      <label scLabel for="email">Email</label>
-                      <input
-                        scInput
-                        id="email"
-                        type="email"
-                        placeholder="john.doe@example.com"
-                      />
-                    </div>
-                    <div class="space-y-2">
-                      <label scLabel for="bio">Bio</label>
-                      <textarea
-                        scTextarea
-                        id="bio"
-                        placeholder="Tell us a little about yourself"
-                        rows="4"
-                      ></textarea>
+                <div scCard>
+                  <div scCardHeader>
+                    <h3 scCardTitle>Profile Information</h3>
+                    <p scCardDescription>Update your profile details below.</p>
+                  </div>
+                  <div scCardBody>
+                    <div class="space-y-4">
+                      <div class="space-y-2">
+                        <label scLabel for="display-name">Display Name</label>
+                        <input
+                          scInput
+                          id="display-name"
+                          type="text"
+                          placeholder="John Doe"
+                        />
+                      </div>
+                      <div class="space-y-2">
+                        <label scLabel for="email">Email</label>
+                        <input
+                          scInput
+                          id="email"
+                          type="email"
+                          placeholder="john.doe@example.com"
+                        />
+                      </div>
+                      <div class="space-y-2">
+                        <label scLabel for="bio">Bio</label>
+                        <textarea
+                          scTextarea
+                          id="bio"
+                          placeholder="Tell us a little about yourself"
+                          rows="4"
+                        ></textarea>
+                      </div>
                     </div>
                   </div>
-                </div>
-                <div scCardFooter class="flex justify-end border-t px-4 py-3">
-                  <button scButton>Save Changes</button>
+                  <div scCardFooter class="flex justify-end border-t px-4 py-3">
+                    <button scButton>Save Changes</button>
+                  </div>
                 </div>
               </div>
-            </div>
+            </ng-template>
           </div>
 
           <div scTabPanel value="account">
-            <div class="space-y-6 pt-6">
-              <div scCard>
-                <div scCardHeader>
-                  <h3 scCardTitle>Change Password</h3>
-                  <p scCardDescription>
-                    Update your password to keep your account secure.
-                  </p>
-                </div>
-                <div scCardBody>
-                  <div class="space-y-4">
-                    <div class="space-y-2">
-                      <label scLabel for="current-password">
-                        Current Password
-                      </label>
-                      <input
-                        scInput
-                        id="current-password"
-                        type="password"
-                        placeholder="Enter current password"
-                      />
-                    </div>
-                    <div class="space-y-2">
-                      <label scLabel for="new-password">New Password</label>
-                      <input
-                        scInput
-                        id="new-password"
-                        type="password"
-                        placeholder="Enter new password"
-                      />
-                    </div>
-                    <div class="space-y-2">
-                      <label scLabel for="confirm-password">
-                        Confirm Password
-                      </label>
-                      <input
-                        scInput
-                        id="confirm-password"
-                        type="password"
-                        placeholder="Confirm new password"
-                      />
+            <ng-template scTabContent>
+              <div class="space-y-6 pt-6">
+                <div scCard>
+                  <div scCardHeader>
+                    <h3 scCardTitle>Change Password</h3>
+                    <p scCardDescription>
+                      Update your password to keep your account secure.
+                    </p>
+                  </div>
+                  <div scCardBody>
+                    <div class="space-y-4">
+                      <div class="space-y-2">
+                        <label scLabel for="current-password">
+                          Current Password
+                        </label>
+                        <input
+                          scInput
+                          id="current-password"
+                          type="password"
+                          placeholder="Enter current password"
+                        />
+                      </div>
+                      <div class="space-y-2">
+                        <label scLabel for="new-password">New Password</label>
+                        <input
+                          scInput
+                          id="new-password"
+                          type="password"
+                          placeholder="Enter new password"
+                        />
+                      </div>
+                      <div class="space-y-2">
+                        <label scLabel for="confirm-password">
+                          Confirm Password
+                        </label>
+                        <input
+                          scInput
+                          id="confirm-password"
+                          type="password"
+                          placeholder="Confirm new password"
+                        />
+                      </div>
                     </div>
                   </div>
+                  <div scCardFooter class="flex justify-end border-t px-4 py-3">
+                    <button scButton>Update Password</button>
+                  </div>
                 </div>
-                <div scCardFooter class="flex justify-end border-t px-4 py-3">
-                  <button scButton>Update Password</button>
-                </div>
-              </div>
 
-              <div scCard>
-                <div scCardHeader>
-                  <h3 scCardTitle>Danger Zone</h3>
-                  <p scCardDescription>Irreversible and destructive actions.</p>
-                </div>
-                <div scCardBody>
-                  <div class="flex items-center justify-between">
-                    <div>
-                      <p class="text-sm font-medium">Delete Account</p>
-                      <p class="text-muted-foreground text-sm">
-                        Permanently delete your account and all of your data.
-                      </p>
+                <div scCard>
+                  <div scCardHeader>
+                    <h3 scCardTitle>Danger Zone</h3>
+                    <p scCardDescription>
+                      Irreversible and destructive actions.
+                    </p>
+                  </div>
+                  <div scCardBody>
+                    <div class="flex items-center justify-between">
+                      <div>
+                        <p class="text-sm font-medium">Delete Account</p>
+                        <p class="text-muted-foreground text-sm">
+                          Permanently delete your account and all of your data.
+                        </p>
+                      </div>
+                      <button scButton variant="destructive">
+                        Delete Account
+                      </button>
                     </div>
-                    <button scButton variant="destructive">
-                      Delete Account
-                    </button>
                   </div>
                 </div>
               </div>
-            </div>
+            </ng-template>
           </div>
 
           <div scTabPanel value="notifications">
-            <div class="space-y-6 pt-6">
-              <div scCard>
-                <div scCardHeader>
-                  <h3 scCardTitle>Notification Preferences</h3>
-                  <p scCardDescription>Choose how you want to be notified.</p>
-                </div>
-                <div scCardBody>
-                  <div class="space-y-4">
-                    <label
-                      scSwitchField
-                      class="flex items-center justify-between rounded-lg border p-4"
-                    >
-                      <div>
-                        <p scLabelText>Email Notifications</p>
-                        <p scFieldDescription>
-                          Receive notifications via email.
-                        </p>
-                      </div>
-                      <input type="checkbox" scSwitch [checked]="true" />
-                    </label>
+            <ng-template scTabContent>
+              <div class="space-y-6 pt-6">
+                <div scCard>
+                  <div scCardHeader>
+                    <h3 scCardTitle>Notification Preferences</h3>
+                    <p scCardDescription>Choose how you want to be notified.</p>
+                  </div>
+                  <div scCardBody>
+                    <div class="space-y-4">
+                      <label
+                        scSwitchField
+                        class="flex items-center justify-between rounded-lg border p-4"
+                      >
+                        <div>
+                          <p scLabelText>Email Notifications</p>
+                          <p scFieldDescription>
+                            Receive notifications via email.
+                          </p>
+                        </div>
+                        <input type="checkbox" scSwitch [checked]="true" />
+                      </label>
 
-                    <label
-                      scSwitchField
-                      class="flex items-center justify-between rounded-lg border p-4"
-                    >
-                      <div>
-                        <p scLabelText>Push Notifications</p>
-                        <p scFieldDescription>
-                          Receive push notifications on your device.
-                        </p>
-                      </div>
-                      <input type="checkbox" scSwitch [checked]="true" />
-                    </label>
+                      <label
+                        scSwitchField
+                        class="flex items-center justify-between rounded-lg border p-4"
+                      >
+                        <div>
+                          <p scLabelText>Push Notifications</p>
+                          <p scFieldDescription>
+                            Receive push notifications on your device.
+                          </p>
+                        </div>
+                        <input type="checkbox" scSwitch [checked]="true" />
+                      </label>
 
-                    <label
-                      scSwitchField
-                      class="flex items-center justify-between rounded-lg border p-4"
-                    >
-                      <div>
-                        <p scLabelText>Marketing Emails</p>
-                        <p scFieldDescription>
-                          Receive emails about new features and updates.
-                        </p>
-                      </div>
-                      <input type="checkbox" scSwitch />
-                    </label>
+                      <label
+                        scSwitchField
+                        class="flex items-center justify-between rounded-lg border p-4"
+                      >
+                        <div>
+                          <p scLabelText>Marketing Emails</p>
+                          <p scFieldDescription>
+                            Receive emails about new features and updates.
+                          </p>
+                        </div>
+                        <input type="checkbox" scSwitch />
+                      </label>
 
-                    <label
-                      scSwitchField
-                      class="flex items-center justify-between rounded-lg border p-4"
-                    >
-                      <div>
-                        <p scLabelText>Security Alerts</p>
-                        <p scFieldDescription>
-                          Get notified about security events on your account.
-                        </p>
-                      </div>
-                      <input type="checkbox" scSwitch [checked]="true" />
-                    </label>
+                      <label
+                        scSwitchField
+                        class="flex items-center justify-between rounded-lg border p-4"
+                      >
+                        <div>
+                          <p scLabelText>Security Alerts</p>
+                          <p scFieldDescription>
+                            Get notified about security events on your account.
+                          </p>
+                        </div>
+                        <input type="checkbox" scSwitch [checked]="true" />
+                      </label>
+                    </div>
                   </div>
                 </div>
               </div>
-            </div>
+            </ng-template>
           </div>
 
           <div scTabPanel value="appearance">
-            <div class="space-y-6 pt-6">
-              <div scCard>
-                <div scCardHeader>
-                  <h3 scCardTitle>Theme</h3>
-                  <p scCardDescription>
-                    Select your preferred theme for the application.
-                  </p>
-                </div>
-                <div scCardBody>
-                  <div class="grid grid-cols-3 gap-4">
-                    <button
-                      scButton
-                      variant="outline"
-                      class="h-auto flex-col gap-2 p-4"
-                    >
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        width="24"
-                        height="24"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        stroke-width="2"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        class="size-6"
+            <ng-template scTabContent>
+              <div class="space-y-6 pt-6">
+                <div scCard>
+                  <div scCardHeader>
+                    <h3 scCardTitle>Theme</h3>
+                    <p scCardDescription>
+                      Select your preferred theme for the application.
+                    </p>
+                  </div>
+                  <div scCardBody>
+                    <div class="grid grid-cols-3 gap-4">
+                      <button
+                        scButton
+                        variant="outline"
+                        class="h-auto flex-col gap-2 p-4"
                       >
-                        <circle cx="12" cy="12" r="4" />
-                        <path d="M12 2v2" />
-                        <path d="M12 20v2" />
-                        <path d="m4.93 4.93 1.41 1.41" />
-                        <path d="m17.66 17.66 1.41 1.41" />
-                        <path d="M2 12h2" />
-                        <path d="M20 12h2" />
-                        <path d="m6.34 17.66-1.41 1.41" />
-                        <path d="m19.07 4.93-1.41 1.41" />
-                      </svg>
-                      <span class="text-sm font-medium">Light</span>
-                    </button>
-                    <button
-                      scButton
-                      variant="outline"
-                      class="h-auto flex-col gap-2 p-4"
-                    >
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        width="24"
-                        height="24"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        stroke-width="2"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        class="size-6"
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          width="24"
+                          height="24"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-width="2"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          class="size-6"
+                        >
+                          <circle cx="12" cy="12" r="4" />
+                          <path d="M12 2v2" />
+                          <path d="M12 20v2" />
+                          <path d="m4.93 4.93 1.41 1.41" />
+                          <path d="m17.66 17.66 1.41 1.41" />
+                          <path d="M2 12h2" />
+                          <path d="M20 12h2" />
+                          <path d="m6.34 17.66-1.41 1.41" />
+                          <path d="m19.07 4.93-1.41 1.41" />
+                        </svg>
+                        <span class="text-sm font-medium">Light</span>
+                      </button>
+                      <button
+                        scButton
+                        variant="outline"
+                        class="h-auto flex-col gap-2 p-4"
                       >
-                        <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z" />
-                      </svg>
-                      <span class="text-sm font-medium">Dark</span>
-                    </button>
-                    <button
-                      scButton
-                      variant="outline"
-                      class="h-auto flex-col gap-2 p-4"
-                    >
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        width="24"
-                        height="24"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        stroke-width="2"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        class="size-6"
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          width="24"
+                          height="24"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-width="2"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          class="size-6"
+                        >
+                          <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z" />
+                        </svg>
+                        <span class="text-sm font-medium">Dark</span>
+                      </button>
+                      <button
+                        scButton
+                        variant="outline"
+                        class="h-auto flex-col gap-2 p-4"
                       >
-                        <rect width="20" height="14" x="2" y="3" rx="2" />
-                        <line x1="8" x2="16" y1="21" y2="21" />
-                        <line x1="12" x2="12" y1="17" y2="21" />
-                      </svg>
-                      <span class="text-sm font-medium">System</span>
-                    </button>
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          width="24"
+                          height="24"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-width="2"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          class="size-6"
+                        >
+                          <rect width="20" height="14" x="2" y="3" rx="2" />
+                          <line x1="8" x2="16" y1="21" y2="21" />
+                          <line x1="12" x2="12" y1="17" y2="21" />
+                        </svg>
+                        <span class="text-sm font-medium">System</span>
+                      </button>
+                    </div>
                   </div>
                 </div>
               </div>
-            </div>
+            </ng-template>
           </div>
         </div>
       </div>

--- a/apps/blocks/src/app/pages/shadcn/shadcn.page.ts
+++ b/apps/blocks/src/app/pages/shadcn/shadcn.page.ts
@@ -30,6 +30,7 @@ import {
   ScProgress,
   ScSeparator,
   ScTab,
+  ScTabContent,
   ScTabList,
   ScTabPanel,
   ScTabs,
@@ -78,6 +79,7 @@ import {
     ScProgress,
     ScSeparator,
     ScTab,
+    ScTabContent,
     ScTabList,
     ScTabPanel,
     ScTabs,
@@ -664,57 +666,69 @@ import {
                     <button scTab value="drinks">Drinks</button>
                   </div>
                   <div scTabPanel value="starters">
-                    <div class="space-y-4 pt-4">
-                      @for (item of menuStarters; track item.name) {
-                        <div
-                          class="flex items-start justify-between gap-4 rounded-lg border p-4"
-                        >
-                          <div class="flex-1 space-y-1">
-                            <div class="flex items-center gap-2">
-                              <span class="text-lg">{{ item.emoji }}</span>
-                              <h4 class="font-medium">{{ item.name }}</h4>
+                    <ng-template scTabContent>
+                      <div class="space-y-4 pt-4">
+                        @for (item of menuStarters; track item.name) {
+                          <div
+                            class="flex items-start justify-between gap-4 rounded-lg border p-4"
+                          >
+                            <div class="flex-1 space-y-1">
+                              <div class="flex items-center gap-2">
+                                <span class="text-lg">{{ item.emoji }}</span>
+                                <h4 class="font-medium">{{ item.name }}</h4>
+                              </div>
+                              <div class="flex gap-1">
+                                @for (tag of item.tags; track tag) {
+                                  <span
+                                    scBadge
+                                    variant="outline"
+                                    class="text-xs"
+                                  >
+                                    {{ tag }}
+                                  </span>
+                                }
+                              </div>
+                              <p class="text-muted-foreground text-sm">
+                                {{ item.description }}
+                              </p>
                             </div>
-                            <div class="flex gap-1">
-                              @for (tag of item.tags; track tag) {
-                                <span scBadge variant="outline" class="text-xs">
-                                  {{ tag }}
-                                </span>
-                              }
+                            <div class="flex flex-col items-end gap-2">
+                              <span class="font-semibold">
+                                \${{ item.price }}
+                              </span>
+                              <button scButton size="sm">Add</button>
                             </div>
-                            <p class="text-muted-foreground text-sm">
-                              {{ item.description }}
-                            </p>
                           </div>
-                          <div class="flex flex-col items-end gap-2">
-                            <span class="font-semibold">
-                              \${{ item.price }}
-                            </span>
-                            <button scButton size="sm">Add</button>
-                          </div>
-                        </div>
-                      }
-                    </div>
+                        }
+                      </div>
+                    </ng-template>
                   </div>
                   <div scTabPanel value="mains">
-                    <div
-                      class="text-muted-foreground flex h-32 items-center justify-center text-sm"
-                    >
-                      Main courses coming soon
-                    </div>
+                    <ng-template scTabContent>
+                      <div
+                        class="text-muted-foreground flex h-32 items-center justify-center text-sm"
+                      >
+                        Main courses coming soon
+                      </div>
+                    </ng-template>
                   </div>
                   <div scTabPanel value="desserts">
-                    <div
-                      class="text-muted-foreground flex h-32 items-center justify-center text-sm"
-                    >
-                      Desserts coming soon
-                    </div>
+                    <ng-template scTabContent>
+                      <div
+                        class="text-muted-foreground flex h-32 items-center justify-center text-sm"
+                      >
+                        Desserts coming soon
+                      </div>
+                    </ng-template>
                   </div>
                   <div scTabPanel value="drinks">
-                    <div
-                      class="text-muted-foreground flex h-32 items-center justify-center text-sm"
-                    >
-                      Drinks coming soon
-                    </div>
+                    <ng-template scTabContent>
+                      <div
+                        class="text-muted-foreground flex h-32 items-center justify-center text-sm"
+                      >
+                        Drinks coming soon
+                      </div>
+                    </ng-template>
                   </div>
                 </div>
               </div>

--- a/apps/showcase/src/app/components/demo-container/demo-container.ts
+++ b/apps/showcase/src/app/components/demo-container/demo-container.ts
@@ -10,6 +10,7 @@ import {
   ScButton,
   ScCopyToClipboard,
   ScTab,
+  ScTabContent,
   ScTabList,
   ScTabPanel,
   ScTabs,
@@ -29,6 +30,7 @@ import { TocHeading } from '../toc/toc-heading';
     ScTabList,
     ScTab,
     ScTabPanel,
+    ScTabContent,
     ScCodeViewer,
     ScCodeViewerHeader,
     ScCodeViewerLabel,
@@ -74,35 +76,39 @@ import { TocHeading } from '../toc/toc-heading';
           value="preview"
           class="flex min-h-40 items-center justify-center rounded-md border p-6"
         >
-          <ng-content />
+          <ng-template scTabContent>
+            <ng-content />
+          </ng-template>
         </div>
 
         <div scTabPanel value="code">
-          <div scCodeViewer>
-            <div scCodeViewerHeader>
-              <span scCodeViewerLabel>{{ language() }}</span>
-              <button
-                scButton
-                variant="ghost"
-                size="icon"
-                [scCopyToClipboard]="code()"
-                #copy="scCopyToClipboard"
-                aria-label="Copy to clipboard"
-              >
-                @if (copy.copied()) {
-                  <svg siCheckIcon></svg>
-                } @else {
-                  <svg siCopyIcon></svg>
-                }
-              </button>
+          <ng-template scTabContent>
+            <div scCodeViewer>
+              <div scCodeViewerHeader>
+                <span scCodeViewerLabel>{{ language() }}</span>
+                <button
+                  scButton
+                  variant="ghost"
+                  size="icon"
+                  [scCopyToClipboard]="code()"
+                  #copy="scCopyToClipboard"
+                  aria-label="Copy to clipboard"
+                >
+                  @if (copy.copied()) {
+                    <svg siCheckIcon></svg>
+                  } @else {
+                    <svg siCopyIcon></svg>
+                  }
+                </button>
+              </div>
+              <div
+                scCodeViewerContent
+                [code]="code()"
+                [language]="language()"
+                [showLineNumbers]="true"
+              ></div>
             </div>
-            <div
-              scCodeViewerContent
-              [code]="code()"
-              [language]="language()"
-              [showLineNumbers]="true"
-            ></div>
-          </div>
+          </ng-template>
         </div>
       </div>
     </div>

--- a/apps/showcase/src/app/pages/docs/tabs/demos/basic-tabs-demo-container.ts
+++ b/apps/showcase/src/app/pages/docs/tabs/demos/basic-tabs-demo-container.ts
@@ -25,6 +25,7 @@ import {
   ScInput,
   ScLabel,
   ScTab,
+  ScTabContent,
   ScTabList,
   ScTabPanel,
   ScTabs,
@@ -35,6 +36,7 @@ import {
   imports: [
     ScTabs,
     ScTabPanel,
+    ScTabContent,
     ScTabList,
     ScTab,
     ScField,
@@ -49,42 +51,46 @@ import {
         <button scTab value="password">Password</button>
       </div>
       <div scTabPanel value="account">
-        <div class="space-y-4 rounded-lg border p-4">
-          <div class="space-y-2">
-            <h3 class="text-lg font-medium">Account</h3>
-            <p class="text-muted-foreground text-sm">
-              Make changes to your account here. Click save when you're done.
-            </p>
+        <ng-template scTabContent>
+          <div class="space-y-4 rounded-lg border p-4">
+            <div class="space-y-2">
+              <h3 class="text-lg font-medium">Account</h3>
+              <p class="text-muted-foreground text-sm">
+                Make changes to your account here. Click save when you're done.
+              </p>
+            </div>
+            <div scField>
+              <label scLabel>Name</label>
+              <input scInput value="Pedro Duarte" />
+            </div>
+            <div scField>
+              <label scLabel>Username</label>
+              <input scInput value="@peduarte" />
+            </div>
+            <button scButton>Save changes</button>
           </div>
-          <div scField>
-            <label scLabel>Name</label>
-            <input scInput value="Pedro Duarte" />
-          </div>
-          <div scField>
-            <label scLabel>Username</label>
-            <input scInput value="@peduarte" />
-          </div>
-          <button scButton>Save changes</button>
-        </div>
+        </ng-template>
       </div>
       <div scTabPanel value="password">
-        <div class="space-y-4 rounded-lg border p-4">
-          <div class="space-y-2">
-            <h3 class="text-lg font-medium">Password</h3>
-            <p class="text-muted-foreground text-sm">
-              Change your password here. After saving, you'll be logged out.
-            </p>
+        <ng-template scTabContent>
+          <div class="space-y-4 rounded-lg border p-4">
+            <div class="space-y-2">
+              <h3 class="text-lg font-medium">Password</h3>
+              <p class="text-muted-foreground text-sm">
+                Change your password here. After saving, you'll be logged out.
+              </p>
+            </div>
+            <div scField>
+              <label scLabel>Current password</label>
+              <input scInput type="password" />
+            </div>
+            <div scField>
+              <label scLabel>New password</label>
+              <input scInput type="password" />
+            </div>
+            <button scButton>Save password</button>
           </div>
-          <div scField>
-            <label scLabel>Current password</label>
-            <input scInput type="password" />
-          </div>
-          <div scField>
-            <label scLabel>New password</label>
-            <input scInput type="password" />
-          </div>
-          <button scButton>Save password</button>
-        </div>
+        </ng-template>
       </div>
     </div>
   \`,

--- a/apps/showcase/src/app/pages/docs/tabs/demos/basic-tabs-demo.ts
+++ b/apps/showcase/src/app/pages/docs/tabs/demos/basic-tabs-demo.ts
@@ -5,6 +5,7 @@ import {
   ScInput,
   ScLabel,
   ScTab,
+  ScTabContent,
   ScTabList,
   ScTabPanel,
   ScTabs,
@@ -15,6 +16,7 @@ import {
   imports: [
     ScTabs,
     ScTabPanel,
+    ScTabContent,
     ScTabList,
     ScTab,
     ScField,
@@ -29,42 +31,46 @@ import {
         <button scTab value="password">Password</button>
       </div>
       <div scTabPanel value="account">
-        <div class="space-y-4 rounded-lg border p-4">
-          <div class="space-y-2">
-            <h3 class="text-lg font-medium">Account</h3>
-            <p class="text-muted-foreground text-sm">
-              Make changes to your account here. Click save when you're done.
-            </p>
+        <ng-template scTabContent>
+          <div class="space-y-4 rounded-lg border p-4">
+            <div class="space-y-2">
+              <h3 class="text-lg font-medium">Account</h3>
+              <p class="text-muted-foreground text-sm">
+                Make changes to your account here. Click save when you're done.
+              </p>
+            </div>
+            <div scField>
+              <label scLabel>Name</label>
+              <input scInput value="Pedro Duarte" />
+            </div>
+            <div scField>
+              <label scLabel>Username</label>
+              <input scInput value="@peduarte" />
+            </div>
+            <button scButton>Save changes</button>
           </div>
-          <div scField>
-            <label scLabel>Name</label>
-            <input scInput value="Pedro Duarte" />
-          </div>
-          <div scField>
-            <label scLabel>Username</label>
-            <input scInput value="@peduarte" />
-          </div>
-          <button scButton>Save changes</button>
-        </div>
+        </ng-template>
       </div>
       <div scTabPanel value="password">
-        <div class="space-y-4 rounded-lg border p-4">
-          <div class="space-y-2">
-            <h3 class="text-lg font-medium">Password</h3>
-            <p class="text-muted-foreground text-sm">
-              Change your password here. After saving, you'll be logged out.
-            </p>
+        <ng-template scTabContent>
+          <div class="space-y-4 rounded-lg border p-4">
+            <div class="space-y-2">
+              <h3 class="text-lg font-medium">Password</h3>
+              <p class="text-muted-foreground text-sm">
+                Change your password here. After saving, you'll be logged out.
+              </p>
+            </div>
+            <div scField>
+              <label scLabel>Current password</label>
+              <input scInput type="password" />
+            </div>
+            <div scField>
+              <label scLabel>New password</label>
+              <input scInput type="password" />
+            </div>
+            <button scButton>Save password</button>
           </div>
-          <div scField>
-            <label scLabel>Current password</label>
-            <input scInput type="password" />
-          </div>
-          <div scField>
-            <label scLabel>New password</label>
-            <input scInput type="password" />
-          </div>
-          <button scButton>Save password</button>
-        </div>
+        </ng-template>
       </div>
     </div>
   `,

--- a/apps/showcase/src/app/pages/docs/tabs/demos/disabled-tabs-demo-container.ts
+++ b/apps/showcase/src/app/pages/docs/tabs/demos/disabled-tabs-demo-container.ts
@@ -19,11 +19,17 @@ import { DisabledTabsDemo } from './disabled-tabs-demo';
 })
 export class DisabledTabsDemoContainer {
   readonly code = `import { Component, ViewEncapsulation } from '@angular/core';
-import { ScTab, ScTabList, ScTabPanel, ScTabs } from '@semantic-components/ui';
+import {
+  ScTab,
+  ScTabContent,
+  ScTabList,
+  ScTabPanel,
+  ScTabs,
+} from '@semantic-components/ui';
 
 @Component({
   selector: 'app-disabled-tabs-demo',
-  imports: [ScTabs, ScTabPanel, ScTabList, ScTab],
+  imports: [ScTabs, ScTabPanel, ScTabContent, ScTabList, ScTab],
   template: \`
     <div scTabs class="w-[500px]">
       <div scTabList [selectedTab]="'overview'">
@@ -35,24 +41,32 @@ import { ScTab, ScTabList, ScTabPanel, ScTabs } from '@semantic-components/ui';
         </button>
       </div>
       <div scTabPanel value="overview">
-        <p class="text-muted-foreground text-sm">
-          Overview content. View your dashboard summary and key metrics.
-        </p>
+        <ng-template scTabContent>
+          <p class="text-muted-foreground text-sm">
+            Overview content. View your dashboard summary and key metrics.
+          </p>
+        </ng-template>
       </div>
       <div scTabPanel value="analytics">
-        <p class="text-muted-foreground text-sm">
-          Analytics content. Dive deep into your data and discover insights.
-        </p>
+        <ng-template scTabContent>
+          <p class="text-muted-foreground text-sm">
+            Analytics content. Dive deep into your data and discover insights.
+          </p>
+        </ng-template>
       </div>
       <div scTabPanel value="reports">
-        <p class="text-muted-foreground text-sm">
-          Reports content. Generate and download detailed reports.
-        </p>
+        <ng-template scTabContent>
+          <p class="text-muted-foreground text-sm">
+            Reports content. Generate and download detailed reports.
+          </p>
+        </ng-template>
       </div>
       <div scTabPanel value="notifications">
-        <p class="text-muted-foreground text-sm">
-          Notifications content. Manage your notification preferences.
-        </p>
+        <ng-template scTabContent>
+          <p class="text-muted-foreground text-sm">
+            Notifications content. Manage your notification preferences.
+          </p>
+        </ng-template>
       </div>
     </div>
   \`,

--- a/apps/showcase/src/app/pages/docs/tabs/demos/disabled-tabs-demo.ts
+++ b/apps/showcase/src/app/pages/docs/tabs/demos/disabled-tabs-demo.ts
@@ -1,9 +1,15 @@
 import { Component, ViewEncapsulation } from '@angular/core';
-import { ScTab, ScTabList, ScTabPanel, ScTabs } from '@semantic-components/ui';
+import {
+  ScTab,
+  ScTabContent,
+  ScTabList,
+  ScTabPanel,
+  ScTabs,
+} from '@semantic-components/ui';
 
 @Component({
   selector: 'app-disabled-tabs-demo',
-  imports: [ScTabs, ScTabPanel, ScTabList, ScTab],
+  imports: [ScTabs, ScTabPanel, ScTabContent, ScTabList, ScTab],
   template: `
     <div scTabs class="w-[500px]">
       <div scTabList [selectedTab]="'overview'">
@@ -15,24 +21,32 @@ import { ScTab, ScTabList, ScTabPanel, ScTabs } from '@semantic-components/ui';
         </button>
       </div>
       <div scTabPanel value="overview">
-        <p class="text-muted-foreground text-sm">
-          Overview content. View your dashboard summary and key metrics.
-        </p>
+        <ng-template scTabContent>
+          <p class="text-muted-foreground text-sm">
+            Overview content. View your dashboard summary and key metrics.
+          </p>
+        </ng-template>
       </div>
       <div scTabPanel value="analytics">
-        <p class="text-muted-foreground text-sm">
-          Analytics content. Dive deep into your data and discover insights.
-        </p>
+        <ng-template scTabContent>
+          <p class="text-muted-foreground text-sm">
+            Analytics content. Dive deep into your data and discover insights.
+          </p>
+        </ng-template>
       </div>
       <div scTabPanel value="reports">
-        <p class="text-muted-foreground text-sm">
-          Reports content. Generate and download detailed reports.
-        </p>
+        <ng-template scTabContent>
+          <p class="text-muted-foreground text-sm">
+            Reports content. Generate and download detailed reports.
+          </p>
+        </ng-template>
       </div>
       <div scTabPanel value="notifications">
-        <p class="text-muted-foreground text-sm">
-          Notifications content. Manage your notification preferences.
-        </p>
+        <ng-template scTabContent>
+          <p class="text-muted-foreground text-sm">
+            Notifications content. Manage your notification preferences.
+          </p>
+        </ng-template>
       </div>
     </div>
   `,

--- a/apps/showcase/src/app/pages/docs/tabs/demos/line-tabs-demo-container.ts
+++ b/apps/showcase/src/app/pages/docs/tabs/demos/line-tabs-demo-container.ts
@@ -19,11 +19,17 @@ import { LineTabsDemo } from './line-tabs-demo';
 })
 export class LineTabsDemoContainer {
   readonly code = `import { Component, ViewEncapsulation } from '@angular/core';
-import { ScTab, ScTabList, ScTabPanel, ScTabs } from '@semantic-components/ui';
+import {
+  ScTab,
+  ScTabContent,
+  ScTabList,
+  ScTabPanel,
+  ScTabs,
+} from '@semantic-components/ui';
 
 @Component({
   selector: 'app-line-tabs-demo',
-  imports: [ScTabs, ScTabPanel, ScTabList, ScTab],
+  imports: [ScTabs, ScTabPanel, ScTabContent, ScTabList, ScTab],
   template: \`
     <div scTabs class="w-[500px]">
       <div scTabList variant="line" [selectedTab]="'overview'">
@@ -32,19 +38,25 @@ import { ScTab, ScTabList, ScTabPanel, ScTabs } from '@semantic-components/ui';
         <button scTab value="reports">Reports</button>
       </div>
       <div scTabPanel value="overview">
-        <p class="text-muted-foreground text-sm">
-          Overview content. View your dashboard summary and key metrics.
-        </p>
+        <ng-template scTabContent>
+          <p class="text-muted-foreground text-sm">
+            Overview content. View your dashboard summary and key metrics.
+          </p>
+        </ng-template>
       </div>
       <div scTabPanel value="analytics">
-        <p class="text-muted-foreground text-sm">
-          Analytics content. Dive deep into your data and discover insights.
-        </p>
+        <ng-template scTabContent>
+          <p class="text-muted-foreground text-sm">
+            Analytics content. Dive deep into your data and discover insights.
+          </p>
+        </ng-template>
       </div>
       <div scTabPanel value="reports">
-        <p class="text-muted-foreground text-sm">
-          Reports content. Generate and download detailed reports.
-        </p>
+        <ng-template scTabContent>
+          <p class="text-muted-foreground text-sm">
+            Reports content. Generate and download detailed reports.
+          </p>
+        </ng-template>
       </div>
     </div>
   \`,

--- a/apps/showcase/src/app/pages/docs/tabs/demos/line-tabs-demo.ts
+++ b/apps/showcase/src/app/pages/docs/tabs/demos/line-tabs-demo.ts
@@ -1,9 +1,15 @@
 import { Component, ViewEncapsulation } from '@angular/core';
-import { ScTab, ScTabList, ScTabPanel, ScTabs } from '@semantic-components/ui';
+import {
+  ScTab,
+  ScTabContent,
+  ScTabList,
+  ScTabPanel,
+  ScTabs,
+} from '@semantic-components/ui';
 
 @Component({
   selector: 'app-line-tabs-demo',
-  imports: [ScTabs, ScTabPanel, ScTabList, ScTab],
+  imports: [ScTabs, ScTabPanel, ScTabContent, ScTabList, ScTab],
   template: `
     <div scTabs class="w-[500px]">
       <div scTabList variant="line" [selectedTab]="'overview'">
@@ -12,19 +18,25 @@ import { ScTab, ScTabList, ScTabPanel, ScTabs } from '@semantic-components/ui';
         <button scTab value="reports">Reports</button>
       </div>
       <div scTabPanel value="overview">
-        <p class="text-muted-foreground text-sm">
-          Overview content. View your dashboard summary and key metrics.
-        </p>
+        <ng-template scTabContent>
+          <p class="text-muted-foreground text-sm">
+            Overview content. View your dashboard summary and key metrics.
+          </p>
+        </ng-template>
       </div>
       <div scTabPanel value="analytics">
-        <p class="text-muted-foreground text-sm">
-          Analytics content. Dive deep into your data and discover insights.
-        </p>
+        <ng-template scTabContent>
+          <p class="text-muted-foreground text-sm">
+            Analytics content. Dive deep into your data and discover insights.
+          </p>
+        </ng-template>
       </div>
       <div scTabPanel value="reports">
-        <p class="text-muted-foreground text-sm">
-          Reports content. Generate and download detailed reports.
-        </p>
+        <ng-template scTabContent>
+          <p class="text-muted-foreground text-sm">
+            Reports content. Generate and download detailed reports.
+          </p>
+        </ng-template>
       </div>
     </div>
   `,

--- a/apps/showcase/src/app/pages/docs/tabs/demos/tabs-usage-demo-container.ts
+++ b/apps/showcase/src/app/pages/docs/tabs/demos/tabs-usage-demo-container.ts
@@ -58,11 +58,17 @@ export class TabsUsageDemoContainer {
   protected readonly devMode = this.config.devMode;
 
   readonly code = `import { Component, ViewEncapsulation } from '@angular/core';
-import { ScTab, ScTabList, ScTabPanel, ScTabs } from '@semantic-components/ui';
+import {
+  ScTab,
+  ScTabContent,
+  ScTabList,
+  ScTabPanel,
+  ScTabs,
+} from '@semantic-components/ui';
 
 @Component({
   selector: 'app-tabs-usage-demo',
-  imports: [ScTabs, ScTabPanel, ScTabList, ScTab],
+  imports: [ScTabs, ScTabPanel, ScTabContent, ScTabList, ScTab],
   template: \`
     <div scTabs class="w-[400px]">
       <div scTabList [selectedTab]="'account'" class="grid w-full grid-cols-2">
@@ -70,14 +76,18 @@ import { ScTab, ScTabList, ScTabPanel, ScTabs } from '@semantic-components/ui';
         <button scTab value="password">Password</button>
       </div>
       <div scTabPanel value="account">
-        <p class="text-muted-foreground p-4 text-sm">
-          Make changes to your account here.
-        </p>
+        <ng-template scTabContent>
+          <p class="text-muted-foreground p-4 text-sm">
+            Make changes to your account here.
+          </p>
+        </ng-template>
       </div>
       <div scTabPanel value="password">
-        <p class="text-muted-foreground p-4 text-sm">
-          Change your password here.
-        </p>
+        <ng-template scTabContent>
+          <p class="text-muted-foreground p-4 text-sm">
+            Change your password here.
+          </p>
+        </ng-template>
       </div>
     </div>
   \`,

--- a/apps/showcase/src/app/pages/docs/tabs/demos/tabs-usage-demo.ts
+++ b/apps/showcase/src/app/pages/docs/tabs/demos/tabs-usage-demo.ts
@@ -1,9 +1,15 @@
 import { Component, ViewEncapsulation } from '@angular/core';
-import { ScTab, ScTabList, ScTabPanel, ScTabs } from '@semantic-components/ui';
+import {
+  ScTab,
+  ScTabContent,
+  ScTabList,
+  ScTabPanel,
+  ScTabs,
+} from '@semantic-components/ui';
 
 @Component({
   selector: 'app-tabs-usage-demo',
-  imports: [ScTabs, ScTabPanel, ScTabList, ScTab],
+  imports: [ScTabs, ScTabPanel, ScTabContent, ScTabList, ScTab],
   template: `
     <div scTabs class="w-[400px]">
       <div scTabList [selectedTab]="'account'" class="grid w-full grid-cols-2">
@@ -11,14 +17,18 @@ import { ScTab, ScTabList, ScTabPanel, ScTabs } from '@semantic-components/ui';
         <button scTab value="password">Password</button>
       </div>
       <div scTabPanel value="account">
-        <p class="text-muted-foreground p-4 text-sm">
-          Make changes to your account here.
-        </p>
+        <ng-template scTabContent>
+          <p class="text-muted-foreground p-4 text-sm">
+            Make changes to your account here.
+          </p>
+        </ng-template>
       </div>
       <div scTabPanel value="password">
-        <p class="text-muted-foreground p-4 text-sm">
-          Change your password here.
-        </p>
+        <ng-template scTabContent>
+          <p class="text-muted-foreground p-4 text-sm">
+            Change your password here.
+          </p>
+        </ng-template>
       </div>
     </div>
   `,

--- a/apps/showcase/src/app/pages/docs/tabs/demos/vertical-tabs-demo-container.ts
+++ b/apps/showcase/src/app/pages/docs/tabs/demos/vertical-tabs-demo-container.ts
@@ -19,11 +19,17 @@ import { VerticalTabsDemo } from './vertical-tabs-demo';
 })
 export class VerticalTabsDemoContainer {
   readonly code = `import { Component, ViewEncapsulation } from '@angular/core';
-import { ScTab, ScTabList, ScTabPanel, ScTabs } from '@semantic-components/ui';
+import {
+  ScTab,
+  ScTabContent,
+  ScTabList,
+  ScTabPanel,
+  ScTabs,
+} from '@semantic-components/ui';
 
 @Component({
   selector: 'app-vertical-tabs-demo',
-  imports: [ScTabs, ScTabPanel, ScTabList, ScTab],
+  imports: [ScTabs, ScTabPanel, ScTabContent, ScTabList, ScTab],
   template: \`
     <div scTabs orientation="vertical" class="w-[500px]">
       <div scTabList [selectedTab]="'account'">
@@ -32,28 +38,34 @@ import { ScTab, ScTabList, ScTabPanel, ScTabs } from '@semantic-components/ui';
         <button scTab value="settings">Settings</button>
       </div>
       <div scTabPanel value="account" class="w-full">
-        <div class="space-y-2 rounded-lg border p-4">
-          <h3 class="text-lg font-medium">Account</h3>
-          <p class="text-muted-foreground text-sm">
-            Manage your account settings and preferences.
-          </p>
-        </div>
+        <ng-template scTabContent>
+          <div class="space-y-2 rounded-lg border p-4">
+            <h3 class="text-lg font-medium">Account</h3>
+            <p class="text-muted-foreground text-sm">
+              Manage your account settings and preferences.
+            </p>
+          </div>
+        </ng-template>
       </div>
       <div scTabPanel value="password" class="w-full">
-        <div class="space-y-2 rounded-lg border p-4">
-          <h3 class="text-lg font-medium">Password</h3>
-          <p class="text-muted-foreground text-sm">
-            Change your password and security settings.
-          </p>
-        </div>
+        <ng-template scTabContent>
+          <div class="space-y-2 rounded-lg border p-4">
+            <h3 class="text-lg font-medium">Password</h3>
+            <p class="text-muted-foreground text-sm">
+              Change your password and security settings.
+            </p>
+          </div>
+        </ng-template>
       </div>
       <div scTabPanel value="settings" class="w-full">
-        <div class="space-y-2 rounded-lg border p-4">
-          <h3 class="text-lg font-medium">Settings</h3>
-          <p class="text-muted-foreground text-sm">
-            Configure your application preferences.
-          </p>
-        </div>
+        <ng-template scTabContent>
+          <div class="space-y-2 rounded-lg border p-4">
+            <h3 class="text-lg font-medium">Settings</h3>
+            <p class="text-muted-foreground text-sm">
+              Configure your application preferences.
+            </p>
+          </div>
+        </ng-template>
       </div>
     </div>
   \`,

--- a/apps/showcase/src/app/pages/docs/tabs/demos/vertical-tabs-demo.ts
+++ b/apps/showcase/src/app/pages/docs/tabs/demos/vertical-tabs-demo.ts
@@ -1,9 +1,15 @@
 import { Component, ViewEncapsulation } from '@angular/core';
-import { ScTab, ScTabList, ScTabPanel, ScTabs } from '@semantic-components/ui';
+import {
+  ScTab,
+  ScTabContent,
+  ScTabList,
+  ScTabPanel,
+  ScTabs,
+} from '@semantic-components/ui';
 
 @Component({
   selector: 'app-vertical-tabs-demo',
-  imports: [ScTabs, ScTabPanel, ScTabList, ScTab],
+  imports: [ScTabs, ScTabPanel, ScTabContent, ScTabList, ScTab],
   template: `
     <div scTabs orientation="vertical" class="w-[500px]">
       <div scTabList [selectedTab]="'account'">
@@ -12,28 +18,34 @@ import { ScTab, ScTabList, ScTabPanel, ScTabs } from '@semantic-components/ui';
         <button scTab value="settings">Settings</button>
       </div>
       <div scTabPanel value="account" class="w-full">
-        <div class="space-y-2 rounded-lg border p-4">
-          <h3 class="text-lg font-medium">Account</h3>
-          <p class="text-muted-foreground text-sm">
-            Manage your account settings and preferences.
-          </p>
-        </div>
+        <ng-template scTabContent>
+          <div class="space-y-2 rounded-lg border p-4">
+            <h3 class="text-lg font-medium">Account</h3>
+            <p class="text-muted-foreground text-sm">
+              Manage your account settings and preferences.
+            </p>
+          </div>
+        </ng-template>
       </div>
       <div scTabPanel value="password" class="w-full">
-        <div class="space-y-2 rounded-lg border p-4">
-          <h3 class="text-lg font-medium">Password</h3>
-          <p class="text-muted-foreground text-sm">
-            Change your password and security settings.
-          </p>
-        </div>
+        <ng-template scTabContent>
+          <div class="space-y-2 rounded-lg border p-4">
+            <h3 class="text-lg font-medium">Password</h3>
+            <p class="text-muted-foreground text-sm">
+              Change your password and security settings.
+            </p>
+          </div>
+        </ng-template>
       </div>
       <div scTabPanel value="settings" class="w-full">
-        <div class="space-y-2 rounded-lg border p-4">
-          <h3 class="text-lg font-medium">Settings</h3>
-          <p class="text-muted-foreground text-sm">
-            Configure your application preferences.
-          </p>
-        </div>
+        <ng-template scTabContent>
+          <div class="space-y-2 rounded-lg border p-4">
+            <h3 class="text-lg font-medium">Settings</h3>
+            <p class="text-muted-foreground text-sm">
+              Configure your application preferences.
+            </p>
+          </div>
+        </ng-template>
       </div>
     </div>
   `,


### PR DESCRIPTION
## Problem

Every docs page load logged a stream of violations from `@angular/aria/tabs`:

```
Violations found on element: <div role="tabpanel" sctabpanel value="preview" …>
ngTabPanel must have an ngTabContent structural directive to render.
```

`TabPanel` requires its content to live in a `TabContent` template. `ScTabContent` (`ng-template[scTabContent]`) already existed and was documented in the tabs README, but no call site used it — every `scTabPanel` in the repo put content directly inside the div.

## Change

Wrapped all 40 panel bodies in `<ng-template scTabContent>` and added `ScTabContent` to the affected components' imports:

- `apps/showcase/src/app/components/demo-container/demo-container.ts` — the Preview/Code panels rendered on every docs page, and the source of the logged violations
- The 5 tabs demos (`basic`, `line`, `disabled`, `vertical`, `usage`)
- The 3 blocks pages: `settings`, `gallery`, `shadcn`

Demo `code` strings were regenerated with `scripts/sync-demo-code.mjs`.

## Notes

- Panel content is now instantiated lazily — the Code tab's syntax highlighting no longer runs on page load for every demo.
- The preview panel projects `<ng-content />` from inside the template. That is supported, but worth a glance in the browser to confirm demos still render on first paint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)