### PR TITLE
fix(menu): skip the leave animation inside a context menu

### DIFF
--- a/libs/ui/src/lib/components/menu/menu.ts
+++ b/libs/ui/src/lib/components/menu/menu.ts
@@ -1,6 +1,7 @@
 import { Menu } from '@angular/aria/menu';
 import { Directive, computed, inject, input } from '@angular/core';
 import { cn } from '../../utils';
+import { SC_CONTEXT_MENU_PROVIDER } from '../context-menu/context-menu-types';
 import { ScMenuPortal } from './menu-portal';
 
 @Directive({
@@ -17,12 +18,26 @@ import { ScMenuPortal } from './menu-portal';
     'data-slot': 'menu',
     '[class]': 'class()',
     'animate.enter': 'animate-in fade-in-0 zoom-in-95 duration-150',
-    'animate.leave': 'animate-out fade-out-0 zoom-out-95 duration-150',
+    '[animate.leave]': 'leaveAnimation()',
   },
 })
 export class ScMenu<V = string> {
   readonly classInput = input<string>('', { alias: 'class' });
   readonly menu = inject<Menu<V>>(Menu);
+
+  /**
+   * A context menu tears its overlay down on close, so the leave animation
+   * never finishes and its classes stay on the element. The next open then
+   * reuses that element and fades in and out at once. Nothing is lost by
+   * skipping it: the pane is destroyed either way.
+   */
+  private readonly contextMenu = inject(SC_CONTEXT_MENU_PROVIDER, {
+    optional: true,
+  });
+
+  protected readonly leaveAnimation = computed(() =>
+    this.contextMenu ? '' : 'animate-out fade-out-0 zoom-out-95 duration-150',
+  );
   readonly visible = this.menu.visible;
 
   protected readonly class = computed(() =>


### PR DESCRIPTION
The context menu blinked on every open after the first — it appeared, faded out, then faded back in.

## Cause

`ScMenu` declares `animate.leave`, so on close Angular holds the element for the 150ms exit. A context menu tears its overlay down immediately, so that animation never finishes and **its classes are never cleaned off**. The next open reuses the same element, appends the enter classes, and both play at once.

Console instrumentation across frames showed it directly:

```
open 1, frames 0–3:  … animate-in fade-in-0 zoom-in-95 duration-150
open 1, frame 4:     … (animation classes gone — cleanup ran)
open 2, frames 0–4:  … zoom-out-95 duration-150 animate-in fade-in-0 …
```

First open: enter classes only, cleaned by frame 4. Second onward: leave *and* enter classes together, on every frame, never cleaned.

The same logs **ruled out the other suspect** — the pane's `transform` was empty and its rect never moved, so nothing was repositioning after paint. My earlier jsdom probe couldn't have found this: jsdom doesn't run animations, so `animate.leave` resolves instantly there and the teardown looks clean.

## Fix

A menu inside a context menu skips the leave animation. Nothing is lost — the pane is destroyed on close either way. Every other menu is unchanged.

```ts
'[animate.leave]': 'leaveAnimation()',
```

The check reads `SC_CONTEXT_MENU_PROVIDER` optionally. Resolution works because the projected menu is *declared* inside the provider, and the element injector follows the declaration site rather than where the overlay moves the DOM.

## Two things worth knowing

- **This puts a context-menu concern inside the shared `ScMenu`.** `ScContextMenu` can't reach a projected child's host bindings, so this was the only workable spot — but it is a little leaky.
- **`multiselect-popup.ts` declares the identical `animate.leave`** and presumably tears its overlay down the same way, so it may carry the same latent bug. Untouched here.

## Verification

`nx test showcase` 56/56; `nx run-many -t lint` exits 0; `nx build ui` exits 0. Behaviour confirmed in the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)