### PR TITLE
fix(showcase): give the package-manager tabs real tab panels

### DIFF
--- a/apps/showcase/src/app/components/package-manager-install/package-manager-install.ts
+++ b/apps/showcase/src/app/components/package-manager-install/package-manager-install.ts
@@ -14,7 +14,9 @@ import {
   ScButton,
   ScCopyToClipboard,
   ScTab,
+  ScTabContent,
   ScTabList,
+  ScTabPanel,
   ScTabs,
 } from '@semantic-components/ui';
 import { cn } from '@semantic-components/ui';
@@ -39,6 +41,8 @@ import { PackageManagerService } from './package-manager.service';
     ScTabs,
     ScTabList,
     ScTab,
+    ScTabPanel,
+    ScTabContent,
   ],
   template: `
     <div scTabs>
@@ -73,7 +77,17 @@ import { PackageManagerService } from './package-manager.service';
             }
           </button>
         </div>
-        <div scCodeViewerContent [code]="command()" language="bash"></div>
+        @for (entry of commands(); track entry.id) {
+          <div scTabPanel [value]="entry.id">
+            <ng-template scTabContent>
+              <div
+                scCodeViewerContent
+                [code]="entry.command"
+                language="bash"
+              ></div>
+            </ng-template>
+          </div>
+        }
       </div>
     </div>
   `,
@@ -91,14 +105,19 @@ export class PackageManagerInstall {
   protected readonly class = computed(() => cn('block', this.classInput()));
   protected readonly selected = this.packageManagerService.selected;
 
-  protected readonly command = computed(() => {
+  protected readonly commands = computed(() => {
     const pkg = this.packages();
-    const commands: Record<string, string> = {
-      npm: `npm install ${pkg}`,
-      yarn: `yarn add ${pkg}`,
-      pnpm: `pnpm add ${pkg}`,
-      bun: `bun add ${pkg}`,
-    };
-    return commands[this.selected()];
+    return [
+      { id: 'pnpm', command: `pnpm add ${pkg}` },
+      { id: 'npm', command: `npm install ${pkg}` },
+      { id: 'yarn', command: `yarn add ${pkg}` },
+      { id: 'bun', command: `bun add ${pkg}` },
+    ];
   });
+
+  protected readonly command = computed(
+    () =>
+      this.commands().find((entry) => entry.id === this.selected())?.command ??
+      '',
+  );
 }

--- a/apps/showcase/src/app/pages/docs/code-viewer/demos/package-manager-code-viewer-demo-container.ts
+++ b/apps/showcase/src/app/pages/docs/code-viewer/demos/package-manager-code-viewer-demo-container.ts
@@ -28,7 +28,9 @@ import {
   ScButton,
   ScCopyToClipboard,
   ScTab,
+  ScTabContent,
   ScTabList,
+  ScTabPanel,
   ScTabs,
 } from '@semantic-components/ui';
 import {
@@ -51,6 +53,8 @@ import {
     ScTabs,
     ScTabList,
     ScTab,
+    ScTabPanel,
+    ScTabContent,
   ],
   template: \`
     <div scTabs class="w-full max-w-lg">
@@ -85,7 +89,17 @@ import {
             }
           </button>
         </div>
-        <div scCodeViewerContent [code]="command()" language="bash"></div>
+        @for (entry of commands; track entry.id) {
+          <div scTabPanel [value]="entry.id">
+            <ng-template scTabContent>
+              <div
+                scCodeViewerContent
+                [code]="entry.command"
+                language="bash"
+              ></div>
+            </ng-template>
+          </div>
+        }
       </div>
     </div>
   \`,
@@ -95,13 +109,16 @@ import {
 export class PackageManagerCodeViewerDemo {
   readonly selected = signal('pnpm');
 
-  private readonly commands: Record<string, string> = {
-    npm: 'npm install @semantic-components/code shiki',
-    yarn: 'yarn add @semantic-components/code shiki',
-    pnpm: 'pnpm add @semantic-components/code shiki',
-    bun: 'bun add @semantic-components/code shiki',
-  };
+  protected readonly commands = [
+    { id: 'pnpm', command: 'pnpm add @semantic-components/code shiki' },
+    { id: 'npm', command: 'npm install @semantic-components/code shiki' },
+    { id: 'yarn', command: 'yarn add @semantic-components/code shiki' },
+    { id: 'bun', command: 'bun add @semantic-components/code shiki' },
+  ];
 
-  readonly command = computed(() => this.commands[this.selected()]);
+  readonly command = computed(
+    () =>
+      this.commands.find((entry) => entry.id === this.selected())?.command ?? '',
+  );
 }`;
 }

--- a/apps/showcase/src/app/pages/docs/code-viewer/demos/package-manager-code-viewer-demo.ts
+++ b/apps/showcase/src/app/pages/docs/code-viewer/demos/package-manager-code-viewer-demo.ts
@@ -8,7 +8,9 @@ import {
   ScButton,
   ScCopyToClipboard,
   ScTab,
+  ScTabContent,
   ScTabList,
+  ScTabPanel,
   ScTabs,
 } from '@semantic-components/ui';
 import {
@@ -31,6 +33,8 @@ import {
     ScTabs,
     ScTabList,
     ScTab,
+    ScTabPanel,
+    ScTabContent,
   ],
   template: `
     <div scTabs class="w-full max-w-lg">
@@ -65,7 +69,17 @@ import {
             }
           </button>
         </div>
-        <div scCodeViewerContent [code]="command()" language="bash"></div>
+        @for (entry of commands; track entry.id) {
+          <div scTabPanel [value]="entry.id">
+            <ng-template scTabContent>
+              <div
+                scCodeViewerContent
+                [code]="entry.command"
+                language="bash"
+              ></div>
+            </ng-template>
+          </div>
+        }
       </div>
     </div>
   `,
@@ -75,12 +89,16 @@ import {
 export class PackageManagerCodeViewerDemo {
   readonly selected = signal('pnpm');
 
-  private readonly commands: Record<string, string> = {
-    npm: 'npm install @semantic-components/code shiki',
-    yarn: 'yarn add @semantic-components/code shiki',
-    pnpm: 'pnpm add @semantic-components/code shiki',
-    bun: 'bun add @semantic-components/code shiki',
-  };
+  protected readonly commands = [
+    { id: 'pnpm', command: 'pnpm add @semantic-components/code shiki' },
+    { id: 'npm', command: 'npm install @semantic-components/code shiki' },
+    { id: 'yarn', command: 'yarn add @semantic-components/code shiki' },
+    { id: 'bun', command: 'bun add @semantic-components/code shiki' },
+  ];
 
-  readonly command = computed(() => this.commands[this.selected()]);
+  readonly command = computed(
+    () =>
+      this.commands.find((entry) => entry.id === this.selected())?.command ??
+      '',
+  );
 }


### PR DESCRIPTION
## Problem

Every docs page load logged four violations from `@angular/aria/tabs`:

```
ngTab with value 'pnpm' does not have a corresponding ngTabPanel.
ngTab with value 'npm'  does not have a corresponding ngTabPanel.
ngTab with value 'yarn' does not have a corresponding ngTabPanel.
ngTab with value 'bun'  does not have a corresponding ngTabPanel.
```

Both package-manager switchers used `scTabList` + `scTab` as a segmented control with **no panels at all** — a single `scCodeViewerContent` whose `[code]` was swapped by the selected signal. The tabs pattern requires each tab to own a panel; that association is also what wires up `aria-controls` / `aria-labelledby`.

## Change

Render one `scTabPanel` per package manager (`@for` over a `{id, command}` list), with the code viewer inside an `<ng-template scTabContent>` so only the selected command's viewer is instantiated. The copy button still copies the selected command via a `command()` computed derived from the same list.

Files:
- `apps/showcase/src/app/components/package-manager-install/package-manager-install.ts`
- `apps/showcase/src/app/pages/docs/code-viewer/demos/package-manager-code-viewer-demo.ts`

Demo `code` string regenerated with `scripts/sync-demo-code.mjs`.

## Note

The code viewer now lives inside a tab panel rather than as a direct sibling of the header, so worth clicking through the tabs to confirm the switcher still sits correctly inside the viewer's frame.

🤖 Generated with [Claude Code](https://claude.com/claude-code)