### PR TITLE
chore(menu): drop the inert cdkAttachPopoverAsChild attribute

### DIFF
--- a/libs/ui/src/lib/components/context-menu/context-menu.ts
+++ b/libs/ui/src/lib/components/context-menu/context-menu.ts
@@ -46,7 +46,6 @@ import { SC_CONTEXT_MENU_PROVIDER } from './context-menu-types';
       }"
       (backdropClick)="close()"
       (overlayKeydown)="onOverlayKeydown($event)"
-      cdkAttachPopoverAsChild
     >
       <ng-content />
     </ng-template>

--- a/libs/ui/src/lib/components/menu-bar/menu-bar-item.ts
+++ b/libs/ui/src/lib/components/menu-bar/menu-bar-item.ts
@@ -47,7 +47,6 @@ import { ScMenuBar } from './menu-bar';
             offsetY: 4,
           },
         ]"
-        cdkAttachPopoverAsChild
       >
         <ng-container [ngTemplateOutlet]="portal.templateRef" />
       </ng-template>

--- a/libs/ui/src/lib/components/menu/menu-item.ts
+++ b/libs/ui/src/lib/components/menu/menu-item.ts
@@ -42,7 +42,6 @@ import { ScMenuPortal } from './menu-portal';
             offsetX: 8,
           },
         ]"
-        cdkAttachPopoverAsChild
       >
         <ng-container [ngTemplateOutlet]="portal.templateRef" />
       </ng-template>

--- a/libs/ui/src/lib/components/menu/menu-provider.ts
+++ b/libs/ui/src/lib/components/menu/menu-provider.ts
@@ -31,7 +31,6 @@ export type ScMenuSide = 'top' | 'bottom';
         [cdkConnectedOverlayOpen]="expanded()"
         [cdkConnectedOverlay]="{ origin, usePopover: 'inline' }"
         [cdkConnectedOverlayPositions]="positions()"
-        cdkAttachPopoverAsChild
       >
         <ng-container [ngTemplateOutlet]="menuPortal().templateRef" />
       </ng-template>


### PR DESCRIPTION
Four deletions, one line per file. **No behaviour change** — the attribute matches nothing in CDK 22.1.1.

| File | |
|---|---|
| `context-menu/context-menu.ts` | line 49 |
| `menu/menu-provider.ts` | line 34 |
| `menu/menu-item.ts` | line 45 |
| `menu-bar/menu-bar-item.ts` | line 50 |

## Why it's inert

There's no such directive, and `CdkConnectedOverlay` has no input by that name — its full input list runs from `cdkConnectedOverlayBackdropClass` to `cdkConnectedOverlayPush`, with nothing popover-as-child in it. A bare attribute matching no directive is silently ignored.

## It was real, briefly

[angular/components#32362](https://github.com/angular/components/pull/32362) added it in November 2025 alongside `cdkCustomPopoverInsertionElement`. **Neither is in the source now.** A code search over `angular/components` finds `cdkAttachPopoverAsChild` in exactly three files — all `aria/menubar` example templates — and `customPopoverInsertionElement` in none. Those stale examples are the likely origin of these lines.

Worth correcting my earlier claim: I first said the API "doesn't exist", which was wrong — it existed, then went away. What's true is that it isn't in our version *or* in the current upstream source.

`usePopover: 'inline'` stays. That's the supported control here, typed `FlexibleOverlayPopoverLocation` and read by the overlay as `popoverLocation`.

## Removed rather than commented

A no-op attribute reads as working behaviour. This one led me to a wrong conclusion about where the overlay attaches while debugging the context menu. Re-adding is one line if the input ever returns, and `git log` will say why it went.

## Verification

`nx test showcase` 56/56; `nx run-many -t lint` exits 0; `nx build ui` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)